### PR TITLE
Release: 0.3.0

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -6,26 +6,12 @@
   "Deadline": "1500s",
   "Sort": ["linter", "severity"],
   "Linters": {
-    "badtime": {
-      "Command": "badtime",
-      "Pattern": "PATH:LINE:COL:MESSAGE"
-    },
-    "durcheck": {
-      "Command": "durcheck",
-      "Pattern": "PATH:LINE:COL:MESSAGE"
-    },
     "errcheck":{
       "Command":"errcheck -ignoretests"
-    },
-    "prealloc":{
-      "Command":"prealloc",
-      "Pattern":"^(?P<path>.*?\\.go):(?P<line>\\d+)\\s*(?P<message>.*)$"
     }
   },
   "Enable": [
-    "badtime",
     "deadcode",
-    "durcheck",
     "errcheck",
     "goconst",
     "gocyclo",
@@ -34,7 +20,6 @@
     "ineffassign",
     "interfacer",
     "maligned",
-    "prealloc",
     "structcheck",
     "unconvert",
     "varcheck",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  pruneopts = ""
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
+
+[[projects]]
   digest = "1:e988ed0ca0d81f4d28772760c02ee95084961311291bdfefc1b04617c178b722"
   name = "github.com/fatih/color"
   packages = ["."]
@@ -34,6 +42,22 @@
   version = "v1.1.2"
 
 [[projects]]
+  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  pruneopts = ""
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:381bcbeb112a51493d9d998bbba207a529c73dbb49b3fd789e48c63fac1f192c"
+  name = "github.com/stretchr/testify"
+  packages = ["assert"]
+  pruneopts = ""
+  revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
+  version = "v1.3.0"
+
+[[projects]]
   digest = "1:e85837cb04b78f61688c6eba93ea9d14f60d611e2aaf8319999b1a60d2dafbfa"
   name = "github.com/urfave/cli"
   packages = ["."]
@@ -63,6 +87,7 @@
   input-imports = [
     "github.com/fatih/color",
     "github.com/mitchellh/mapstructure",
+    "github.com/stretchr/testify/assert",
     "github.com/urfave/cli",
     "gopkg.in/yaml.v2",
   ]

--- a/cli/scaffold/scaffold.go
+++ b/cli/scaffold/scaffold.go
@@ -2,15 +2,16 @@ package scaffold
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+
 	"github.com/urfave/cli"
 	"github.com/x1unix/gilbert/logging"
 	"github.com/x1unix/gilbert/manifest"
 	"github.com/x1unix/gilbert/scope"
 	"gopkg.in/yaml.v2"
-	"io/ioutil"
-	"os"
-	"path"
-	"strings"
 )
 
 var boilerplate = manifest.Manifest{
@@ -22,14 +23,14 @@ var boilerplate = manifest.Manifest{
 		"build": manifest.Task{
 			{
 				Description: "Build project",
-				Plugin:      "build",
+				PluginName:  "build",
 			},
 		},
 		"clean": manifest.Task{
 			{
 				Description: "Remove vendor files",
 				Condition:   "file ./vendor",
-				Plugin:      "shell",
+				PluginName:  "shell",
 				Params: map[string]interface{}{
 					"command": "rm -rf ./vendor",
 				},

--- a/gilbert.yaml
+++ b/gilbert.yaml
@@ -22,13 +22,12 @@ mixins:
 tasks:
   build:
   - plugin: build
-    description: "Building project"
     params:
       variables:
         'main.version': '{{ version }}'
         'main.commit': '{{ commit }}'
   - if: 'uname -a'
-    description: "Show a message only if job runs on UNIX"
+    description: "show a message only if job runs on UNIX"
     plugin: shell
     params:
       command: 'echo This is UNIX machine'

--- a/gilbert.yaml
+++ b/gilbert.yaml
@@ -1,7 +1,7 @@
 version: 1.0
 vars:
   buildDir: './build'
-  version: '0.2.1'
+  version: '0.3.0'
   commit: '{% git log --format=%H -n 1 %}'
 
 mixins:

--- a/gilbert.yaml
+++ b/gilbert.yaml
@@ -13,8 +13,8 @@ mixins:
       params:
         outputPath: '{{buildDir}}/gilbert_{{os}}-{{arch}}{{ext}}'
         target:
-          os: {{os}}
-          arch: {{arch}}
+          os: '{{os}}'
+          arch: '{{arch}}'
         variables:
           'main.version': '{{ version }}'
           'main.commit': '{{ commit }}'
@@ -38,7 +38,7 @@ tasks:
     vars:
       os: windows
       arch: '386'
-      ext: .exe
+      ext: '.exe'
   - mixin: platform-build
     vars:
       os: windows
@@ -53,6 +53,6 @@ tasks:
       os: linux
       arch: 'amd64'
   - mixin: platform-build
-      vars:
-        os: linux
-        arch: '386'
+    vars:
+      os: linux
+      arch: '386'

--- a/gilbert.yaml
+++ b/gilbert.yaml
@@ -3,6 +3,22 @@ vars:
   buildDir: './build'
   version: '0.2.1'
   commit: '{% git log --format=%H -n 1 %}'
+
+mixins:
+  platform-build:
+    - plugin: build
+      description: '{{os}} - {{arch}}'
+      vars:
+        ext: ''
+      params:
+        outputPath: '{{buildDir}}/gilbert_{{os}}-{{arch}}{{ext}}'
+        target:
+          os: {{os}}
+          arch: {{arch}}
+        variables:
+          'main.version': '{{ version }}'
+          'main.commit': '{{ commit }}'
+
 tasks:
   build:
   - plugin: build
@@ -18,47 +34,25 @@ tasks:
       command: 'echo This is UNIX machine'
 
   release:
-  - plugin: build
-    description: 'Windows - 32bit'
-    params:
-      outputPath: '{{buildDir}}/gilbert_i386.exe'
-      target:
-        os: windows
-        arch: '386'
-      variables:
-        'main.version': '{{ version }}'
-        'main.commit': '{{ commit }}'
-
-  - plugin: build
-    description: 'Windows - amd64'
-    params:
-      outputPath: '{{buildDir}}/gilbert_amd64.exe'
-      target:
-        os: windows
-        arch: amd64
-      variables:
-        'main.version': '{{ version }}'
-        'main.commit': '{{ commit }}'
-
-  - plugin: build
-    description: 'MacOS - amd64'
-    params:
-      outputPath: '{{buildDir}}/gilbert_osx'
-      target:
-        os: darwin
-        arch: amd64
-      variables:
-        'main.version': '{{ version }}'
-        'main.commit': '{{ commit }}'
-
-  - plugin: build
-    description: 'Linux - amd64'
-    params:
-      outputPath: '{{buildDir}}/gilbert_linux-amd64'
-      target:
+  - mixin: platform-build
+    vars:
+      os: windows
+      arch: '386'
+      ext: .exe
+  - mixin: platform-build
+    vars:
+      os: windows
+      arch: 'amd64'
+      ext: .exe
+  - mixin: platform-build
+    vars:
+      os: darwin
+      arch: 'amd64'
+  - mixin: platform-build
+    vars:
+      os: linux
+      arch: 'amd64'
+  - mixin: platform-build
+      vars:
         os: linux
-        arch: amd64
-      variables:
-        'main.version': '{{ version }}'
-        'main.commit': '{{ commit }}'
-
+        arch: '386'

--- a/gilbert.yaml
+++ b/gilbert.yaml
@@ -20,6 +20,11 @@ mixins:
           'main.commit': '{{ commit }}'
 
 tasks:
+  pre-install:
+  - plugin: go-get
+    params:
+      packages:
+        - github.com/stretchr/testify
   build:
   - plugin: build
     params:

--- a/gilbert.yaml
+++ b/gilbert.yaml
@@ -7,7 +7,7 @@ vars:
 mixins:
   platform-build:
     - plugin: build
-      description: '{{os}} - {{arch}}'
+      description: 'build for {{os}} {{arch}}'
       vars:
         ext: ''
       params:

--- a/manifest/file.go
+++ b/manifest/file.go
@@ -36,6 +36,9 @@ type Manifest struct {
 	// Tasks is a set of tasks
 	Tasks TaskSet `yaml:"tasks,omitempty"`
 
+	// Mixins is a set of declared mixins
+	Mixins Mixins `yaml:"mixins,omitempty"`
+
 	// location is manifest location
 	location string `yaml:"-"`
 }

--- a/manifest/job.go
+++ b/manifest/job.go
@@ -53,21 +53,37 @@ func (j *Job) HasDescription() bool {
 	return j.Description != ""
 }
 
-// ExecParams returns params to execute the job
+// FormatDescription returns formatted description string
+func (j *Job) FormatDescription() string {
+	if j.Description != "" {
+		return j.Description
+	}
+
+	// If description is empty, return used mixin or plugin name if available
+	for _, v := range []*string{j.PluginName, j.TaskName, j.MixinName} {
+		if v != nil {
+			return *v
+		}
+	}
+
+	return ""
+}
+
+// Type returns job execution type
 //
 // If job has no 'plugin', 'task' or 'plugin' declaration, ExecEmpty will be returned
-func (j *Job) ExecParams() (name string, execType JobExecType) {
+func (j *Job) Type() JobExecType {
 	if j.PluginName != nil {
-		return *j.PluginName, ExecPlugin
+		return ExecPlugin
 	}
 
 	if j.TaskName != nil {
-		return *j.TaskName, ExecTask
+		return ExecTask
 	}
 
 	if j.MixinName != nil {
-		return *j.MixinName, ExecMixin
+		return ExecMixin
 	}
 
-	return "", ExecEmpty
+	return ExecEmpty
 }

--- a/manifest/job.go
+++ b/manifest/job.go
@@ -4,6 +4,23 @@ import (
 	"github.com/x1unix/gilbert/scope"
 )
 
+// JobExecType represents job type
+type JobExecType uint8
+
+const (
+	// ExecEmpty means job has no execution type
+	ExecEmpty JobExecType = iota
+
+	// ExecPlugin means that job execute plugin
+	ExecPlugin
+
+	// ExecTask means that job runs other task
+	ExecTask
+
+	// ExecMixin means that job based on mixin
+	ExecMixin
+)
+
 // Job is a single job in task
 type Job struct {
 	// Condition is shell command that should be successful to run specified job
@@ -34,4 +51,23 @@ type Job struct {
 // HasDescription checks if description is available
 func (j *Job) HasDescription() bool {
 	return j.Description != ""
+}
+
+// ExecParams returns params to execute the job
+//
+// If job has no 'plugin', 'task' or 'plugin' declaration, ExecEmpty will be returned
+func (j *Job) ExecParams() (name string, execType JobExecType) {
+	if j.PluginName != nil {
+		return *j.PluginName, ExecPlugin
+	}
+
+	if j.TaskName != nil {
+		return *j.TaskName, ExecTask
+	}
+
+	if j.MixinName != nil {
+		return *j.MixinName, ExecMixin
+	}
+
+	return "", ExecEmpty
 }

--- a/manifest/job.go
+++ b/manifest/job.go
@@ -12,11 +12,14 @@ type Job struct {
 	// Description is job description
 	Description string `yaml:"description,omitempty"`
 
-	// Task refers to task that should be run.
-	Task string `yaml:"run,omitempty"`
+	// TaskName refers to task that should be run.
+	TaskName *string `yaml:"run,omitempty"`
 
-	// Plugin describes what plugin should handle this job.
-	Plugin string `yaml:"plugin,omitempty"`
+	// PluginName describes what plugin should handle this job.
+	PluginName *string `yaml:"plugin,omitempty"`
+
+	// MixinName is mixin to be used by this job
+	MixinName *string `yaml:"mixin,omitempty"`
 
 	// Delay before task start in milliseconds
 	Delay uint `yaml:"delay,omitempty"`
@@ -26,16 +29,6 @@ type Job struct {
 
 	// Params is a set of arguments for the job.
 	Params map[string]interface{} `yaml:"params,omitempty"`
-}
-
-// InvokesTask checks if this job should call another task
-func (j *Job) InvokesTask() bool {
-	return j.Task != ""
-}
-
-// InvokesPlugin checks if this job should invoke plugin
-func (j *Job) InvokesPlugin() bool {
-	return j.Plugin != ""
 }
 
 // HasDescription checks if description is available

--- a/manifest/job.go
+++ b/manifest/job.go
@@ -30,13 +30,13 @@ type Job struct {
 	Description string `yaml:"description,omitempty"`
 
 	// TaskName refers to task that should be run.
-	TaskName *string `yaml:"run,omitempty"`
+	TaskName string `yaml:"run,omitempty"`
 
 	// PluginName describes what plugin should handle this job.
-	PluginName *string `yaml:"plugin,omitempty"`
+	PluginName string `yaml:"plugin,omitempty"`
 
 	// MixinName is mixin to be used by this job
-	MixinName *string `yaml:"mixin,omitempty"`
+	MixinName string `yaml:"mixin,omitempty"`
 
 	// Delay before task start in milliseconds
 	Delay uint `yaml:"delay,omitempty"`
@@ -60,9 +60,9 @@ func (j *Job) FormatDescription() string {
 	}
 
 	// If description is empty, return used mixin or plugin name if available
-	for _, v := range []*string{j.PluginName, j.TaskName, j.MixinName} {
-		if v != nil {
-			return *v
+	for _, v := range []string{j.PluginName, j.TaskName, j.MixinName} {
+		if v != "" {
+			return v
 		}
 	}
 
@@ -73,15 +73,15 @@ func (j *Job) FormatDescription() string {
 //
 // If job has no 'plugin', 'task' or 'plugin' declaration, ExecEmpty will be returned
 func (j *Job) Type() JobExecType {
-	if j.PluginName != nil {
+	if j.PluginName != "" {
 		return ExecPlugin
 	}
 
-	if j.TaskName != nil {
+	if j.TaskName != "" {
 		return ExecTask
 	}
 
-	if j.MixinName != nil {
+	if j.MixinName != "" {
 		return ExecMixin
 	}
 

--- a/manifest/mixin.go
+++ b/manifest/mixin.go
@@ -1,0 +1,20 @@
+package manifest
+
+import "github.com/x1unix/gilbert/scope"
+
+// Mixin represents a mixin declaration
+type Mixin []Job
+
+// ToTask creates a new task from mixin with variables for override
+func (m Mixin) ToTask(parentVars scope.Vars) (t Task) {
+	t = make(Task, 0, len(m))
+	for _, j := range m {
+		j.Vars.Append(parentVars)
+		t = append(t, j)
+	}
+
+	return t
+}
+
+// Mixins is a pair of mixin name and params
+type Mixins map[string]Mixin

--- a/plugins/builtin/build/builder.go
+++ b/plugins/builtin/build/builder.go
@@ -15,6 +15,10 @@ func NewBuildPlugin(context *scope.Context, params manifest.RawParams, log loggi
 		return nil, manifest.NewPluginConfigError("build", err)
 	}
 
+	if err := context.Scan(&p.Target.Os, &p.Target.Arch); err != nil {
+		return nil, manifest.NewPluginConfigError("build", err)
+	}
+
 	return &Plugin{
 		context: context,
 		params:  p,

--- a/plugins/builtin/build/plugin.go
+++ b/plugins/builtin/build/plugin.go
@@ -22,6 +22,7 @@ func (p *Plugin) Call() error {
 		return err
 	}
 
+	p.log.Debug("Target: %s %s", p.params.Target.Os, p.params.Target.Arch)
 	p.log.Debug("Command: '%s'", strings.Join(cmd.Args, " "))
 	cmd.Stdout = p.log
 	cmd.Stderr = p.log.ErrorWriter()

--- a/plugins/builtin/goget/params.go
+++ b/plugins/builtin/goget/params.go
@@ -1,0 +1,8 @@
+package goget
+
+type params struct {
+	Verbose      bool
+	Update       bool
+	DownloadOnly bool
+	Packages     []string
+}

--- a/plugins/builtin/goget/plugin.go
+++ b/plugins/builtin/goget/plugin.go
@@ -10,6 +10,7 @@ import (
 	"github.com/x1unix/gilbert/scope"
 	"github.com/x1unix/gilbert/tools/shell"
 	"os/exec"
+	"strings"
 )
 
 // Plugin implements gilbert plugin
@@ -61,7 +62,7 @@ func (p *Plugin) getPackage(pkgName string) (err error) {
 	}
 
 	p.log.Info("Downloading package '%s'", pkgName)
-	p.log.Debug(proc.Path)
+	p.log.Debug(strings.Join(proc.Args, " "))
 	if err := proc.Start(); err != nil {
 		return err
 	}

--- a/plugins/builtin/goget/plugin.go
+++ b/plugins/builtin/goget/plugin.go
@@ -74,6 +74,7 @@ func (p *Plugin) getPackage(pkgName string) (err error) {
 	return err
 }
 
+// NewPlugin creates a new plugin instance
 func NewPlugin(context *scope.Context, rawParams manifest.RawParams, log logging.Logger) (plugins.Plugin, error) {
 	p := params{}
 	if err := mapstructure.Decode(rawParams, &p); err != nil {

--- a/plugins/builtin/goget/plugin.go
+++ b/plugins/builtin/goget/plugin.go
@@ -1,0 +1,87 @@
+package goget
+
+import (
+	"errors"
+	"fmt"
+	"github.com/mitchellh/mapstructure"
+	"github.com/x1unix/gilbert/logging"
+	"github.com/x1unix/gilbert/manifest"
+	"github.com/x1unix/gilbert/plugins"
+	"github.com/x1unix/gilbert/scope"
+	"github.com/x1unix/gilbert/tools/shell"
+	"os/exec"
+)
+
+// Plugin implements gilbert plugin
+type Plugin struct {
+	context *scope.Context
+	params  params
+	log     logging.Logger
+}
+
+// Call implements plugins.plugin
+func (p *Plugin) Call() error {
+	if len(p.params.Packages) == 0 {
+		return errors.New("no packages to install")
+	}
+
+	for _, pkg := range p.params.Packages {
+		if err := p.getPackage(pkg); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (p *Plugin) getPackage(pkgName string) (err error) {
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("failed to get package '%s', %s", pkgName, err)
+		}
+	}()
+
+	cmd := []string{"get"}
+	if p.params.DownloadOnly {
+		cmd = append(cmd, "-d")
+	}
+
+	if p.params.Update {
+		cmd = append(cmd, "-u")
+	}
+
+	if p.params.Verbose {
+		cmd = append(cmd, "-v")
+	}
+
+	cmd = append(cmd, pkgName)
+	proc := exec.Command("go", cmd...)
+	if p.params.Verbose {
+		proc.Stdout = p.log
+	}
+
+	p.log.Info("Downloading package '%s'", pkgName)
+	p.log.Debug(proc.Path)
+	if err := proc.Start(); err != nil {
+		return err
+	}
+
+	if err = proc.Wait(); err != nil {
+		return shell.FormatExitError(err)
+	}
+
+	return err
+}
+
+func NewPlugin(context *scope.Context, rawParams manifest.RawParams, log logging.Logger) (plugins.Plugin, error) {
+	p := params{}
+	if err := mapstructure.Decode(rawParams, &p); err != nil {
+		return nil, manifest.NewPluginConfigError("build", err)
+	}
+
+	return &Plugin{
+		context: context,
+		params:  p,
+		log:     log,
+	}, nil
+}

--- a/plugins/builtin/plugins.go
+++ b/plugins/builtin/plugins.go
@@ -3,11 +3,13 @@ package builtin
 import (
 	"github.com/x1unix/gilbert/plugins"
 	"github.com/x1unix/gilbert/plugins/builtin/build"
+	"github.com/x1unix/gilbert/plugins/builtin/goget"
 	"github.com/x1unix/gilbert/plugins/builtin/shell"
 )
 
 // DefaultPlugins is list of default plugins
 var DefaultPlugins = map[string]plugins.PluginFactory{
-	"build": build.NewBuildPlugin,
-	"shell": shell.NewShellPlugin,
+	"build":  build.NewBuildPlugin,
+	"shell":  shell.NewShellPlugin,
+	"go-get": goget.NewPlugin,
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -138,7 +138,7 @@ func (t *TaskRunner) execJobWithMixin(j *manifest.Job, ctx *scope.Context, subLo
 	// Create a task from mixin and job params
 	subLog.Debug("create sub-task from mixin '%s'", j.MixinName)
 	task := mx.ToTask(j.Vars)
-	if err := t.runSubTask(task, subLog.SubLogger(), ctx); err != nil {
+	if err := t.runSubTask(task, subLog, ctx); err != nil {
 		return err
 	}
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -109,7 +109,7 @@ func (t *TaskRunner) runJob(job *manifest.Job, parentVars scope.Vars, subLog log
 	execType := job.Type()
 	switch execType {
 	case manifest.ExecPlugin:
-		factory, err := t.PluginByName(job.TaskName)
+		factory, err := t.PluginByName(job.PluginName)
 		if err != nil {
 			return err
 		}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -100,14 +100,14 @@ func (t *TaskRunner) runJob(job *manifest.Job, parentVars scope.Vars, subLog log
 	execType := job.Type()
 	switch execType {
 	case manifest.ExecPlugin:
-		factory, err := t.PluginByName(*job.TaskName)
+		factory, err := t.PluginByName(job.TaskName)
 		if err != nil {
 			return err
 		}
 
 		plugin, err := factory(ctx, job.Params, subLog)
 		if err != nil {
-			return fmt.Errorf("failed to apply plugin '%s': %v", *job.PluginName, err)
+			return fmt.Errorf("failed to apply plugin '%s': %v", job.PluginName, err)
 		}
 		return plugin.Call()
 	case manifest.ExecMixin:
@@ -121,14 +121,13 @@ func (t *TaskRunner) runJob(job *manifest.Job, parentVars scope.Vars, subLog log
 //
 // requires subLogger instance to create cascade logging output
 func (t *TaskRunner) execJobWithMixin(j *manifest.Job, subLog logging.Logger) error {
-	mixinName := *j.MixinName
-	mx, ok := t.Manifest.Mixins[mixinName]
+	mx, ok := t.Manifest.Mixins[j.MixinName]
 	if !ok {
-		return fmt.Errorf("mixin '%s' doesn't exists", mixinName)
+		return fmt.Errorf("mixin '%s' doesn't exists", j.MixinName)
 	}
 
 	// Create a task from mixin and job params
-	subLog.Debug("create sub-task from mixin '%s'", mixinName)
+	subLog.Debug("create sub-task from mixin '%s'", j.MixinName)
 	task := mx.ToTask(j.Vars)
 	if err := t.runSubTask(task, subLog.SubLogger()); err != nil {
 		return err

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -60,6 +60,11 @@ func (t *TaskRunner) RunTask(taskName string) error {
 	return nil
 }
 
+// runSubTask used to run sub-tasks created by parent job
+//
+// parentCtx used to expand task base properties (like description, etc.)
+//
+// subLogger used to create stack of log lines
 func (t *TaskRunner) runSubTask(task manifest.Task, subLogger logging.Logger, parentCtx *scope.Context) error {
 	steps := len(task)
 
@@ -75,7 +80,13 @@ func (t *TaskRunner) runSubTask(task manifest.Task, subLogger logging.Logger, pa
 			descr = parsed
 		}
 
-		subLogger.Log("Step %d of %d: %s", currentStep, steps, descr)
+		if steps > 1 {
+			// show total steps count only if more than one step provided
+			subLogger.Info("- %s [%d/%d]", descr, currentStep, steps)
+		} else {
+			subLogger.Info("- %s", descr)
+		}
+
 		err := t.runJob(&job, nil, subLogger.SubLogger())
 		if err != nil {
 			return fmt.Errorf("%v (sub-task step %d)", err, currentStep)

--- a/scope/context.go
+++ b/scope/context.go
@@ -54,7 +54,7 @@ func (c *Context) AppendGlobals(globals Vars) *Context {
 	return c
 }
 
-// AppendGlobals appends global variables to the context
+// AppendVariables appends global variables to the context
 func (c *Context) AppendVariables(globals Vars) *Context {
 	for k, v := range globals {
 		c.Globals[k] = v

--- a/scope/context.go
+++ b/scope/context.go
@@ -8,6 +8,17 @@ import (
 // Vars is a set of declared variables
 type Vars map[string]string
 
+// Append appends variables from vars list
+func (v Vars) Append(newVars Vars) {
+	if newVars == nil || len(newVars) == 0 {
+		return
+	}
+
+	for k := range newVars {
+		v[k] = newVars[k]
+	}
+}
+
 // Context contains a set of globals and variables related to specific job
 type Context struct {
 	Globals     Vars // Globals is set of global variables for all tasks
@@ -36,6 +47,15 @@ func CreateContext(projectDirectory string, vars Vars) (c *Context) {
 
 // AppendGlobals appends global variables to the context
 func (c *Context) AppendGlobals(globals Vars) *Context {
+	for k, v := range globals {
+		c.Globals[k] = v
+	}
+
+	return c
+}
+
+// AppendGlobals appends global variables to the context
+func (c *Context) AppendVariables(globals Vars) *Context {
 	for k, v := range globals {
 		c.Globals[k] = v
 	}

--- a/scope/context.go
+++ b/scope/context.go
@@ -88,6 +88,20 @@ func (c *Context) ExpandVariables(str string) (out string, err error) {
 	return c.processor.ReadString(str)
 }
 
+// Scan does the same as ExpandVariables but with multiple variables and updates the value in pointer with expanded value
+//
+// Useful for bulk mapping of struct fields
+func (c *Context) Scan(vals ...*string) (err error) {
+	for _, ptr := range vals {
+		*ptr, err = c.processor.ReadString(*ptr)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // Environ gets list of OS environment variables with globals
 func (c *Context) Environ() (env []string) {
 	env = os.Environ()

--- a/scope/context_test.go
+++ b/scope/context_test.go
@@ -4,7 +4,22 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
+
+func TestVarsScan(t *testing.T) {
+	c := &Context{
+		Variables: Vars{
+			"foo": "bar",
+		},
+	}
+
+	c.processor = NewExpressionProcessor(c)
+	input := "foo{{foo}}"
+	assert.NoError(t, c.Scan(&input))
+	assert.Equal(t, "foobar", input)
+}
 
 func TestVarsExtract(t *testing.T) {
 	c := &Context{


### PR DESCRIPTION
## Changelog

### Breaking changes

None

### Plugins

This release introduces a new `go-get` plugin as an alias for `go get` command.
All params except `packages` are *optional*

```yaml
tasks:
  build:
  - plugin: go-get
    params:
      update: true # -u flag
      verbose: true # for debugging only
      downloadOnly: true # -d flag analog
      packages:
        - github.com/x1unix/gilbert
        - github.com/stretchr/testify
```

### Syntax

#### Mixins

This release introduces *mixins* support. *Mixins* allows to reduce configuration boilerplate by putting shared task steps into a separate section that can be used in different build jobs as job handler.

Here is a sample with cross-platform build using mixins:

```yaml
version: 1.0
vars:
  version: '0.3.0'
  commit: '{% git log --format=%H -n 1 %}'

mixins:
  platform-build:
    - plugin: build
      description: 'build for {{os}} {{arch}}'
      vars:
        ext: ''   # Set default value, could be overriden by parent job
      params:
        outputPath: 'build/gilbert_{{os}}-{{arch}}{{ext}}'
        target:
          os: '{{os}}'  # Value passed from parent job
          arch: '{{arch}}'
        variables:
          'main.version': '{{ version }}'
          'main.commit': '{{ commit }}'

tasks:
  build:
  - mixin: platform-build
    vars:
      os: windows
      arch: '386'
      ext: '.exe'   # Override 'ext' variable for Windows build
  - mixin: platform-build
    vars:
      os: darwin
      arch: 'amd64'
  - mixin: platform-build
    vars:
      os: linux
      arch: 'amd64'
```