### PR TITLE
install: fix architecture detection issue on macOS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -37,7 +37,7 @@ get_gilbert_name() {
 get_arch() {
     a=$(uname -m)
     case ${a} in
-    "x86_64")
+    "x86_64" | "amd64" )
         echo "amd64"
         ;;
     "i386" | "i486" | "i586")

--- a/install.sh
+++ b/install.sh
@@ -35,7 +35,7 @@ get_gilbert_name() {
 }
 
 get_arch() {
-    a=$(arch)
+    a=$(uname -m)
     case ${a} in
     "x86_64")
         echo "amd64"


### PR DESCRIPTION
Use `uname -m` instead of `arch` for macOS compatibility