### PR TITLE
Minor release - 0.5.0

### DIFF
--- a/docs/test_jobs.yaml
+++ b/docs/test_jobs.yaml
@@ -1,0 +1,28 @@
+version: 1.0
+
+mixins:
+  async-test:
+    - plugin: shell
+      async: true
+      params:
+        command: 'foo'
+
+tasks:
+  test-deadline-async:
+    - plugin: shell
+      deadline: 2000
+      async: true
+      params:
+        command: 'sleep 4'
+    - plugin: shell
+      params:
+        command: 'ping -c 5 localhost'
+  test-async:
+    - mixin: async-test
+    - plugin: shell
+      params:
+        command: 'uname -a'
+    - plugin: shell
+      async: true
+      params:
+        command: 'ping -c 5 localhost'

--- a/gilbert.yaml
+++ b/gilbert.yaml
@@ -1,15 +1,13 @@
 version: 1.0
+imports:
+  - ./docs/test_jobs.yaml
+
 vars:
   buildDir: './build'
-  version: '0.4.1'
+  version: '0.5.0'
   commit: '{% git log --format=%H -n 1 %}'
 
 mixins:
-  async-test:
-    - plugin: shell
-      async: true
-      params:
-        command: 'foo'
   platform-build:
     - plugin: build
       description: 'build for {{os}} {{arch}}'
@@ -23,26 +21,7 @@ mixins:
         variables:
           'main.version': '{{ version }}'
           'main.commit': '{{ commit }}'
-
 tasks:
-  test-deadline-async:
-    - plugin: shell
-      deadline: 2000
-      async: true
-      params:
-        command: 'sleep 4'
-    - plugin: shell
-      params:
-        command: 'ping -c 5 localhost'
-  test-async:
-    - mixin: async-test
-    - plugin: shell
-      params:
-        command: 'uname -a'
-    - plugin: shell
-      async: true
-      params:
-        command: 'ping -c 5 localhost'
   install:
   - plugin: build
     params:
@@ -55,11 +34,13 @@ tasks:
     - plugin: shell
       params:
         command: 'gometalinter ./...'
+
   pre-install:
   - plugin: go-get
     params:
       packages:
         - github.com/stretchr/testify
+
   build:
   - plugin: build
     params:

--- a/manifest/file.go
+++ b/manifest/file.go
@@ -1,11 +1,7 @@
 package manifest
 
 import (
-	"fmt"
 	"github.com/x1unix/gilbert/scope"
-	"gopkg.in/yaml.v2"
-	"io/ioutil"
-	"path/filepath"
 )
 
 const (
@@ -40,28 +36,4 @@ type Manifest struct {
 // Location returns manifest file location, if it was loaded using FromDirectory method
 func (m *Manifest) Location() string {
 	return m.location
-}
-
-// UnmarshalManifest parses yaml contents into manifest structure
-func UnmarshalManifest(data []byte) (m *Manifest, err error) {
-	m = &Manifest{}
-	err = yaml.Unmarshal(data, m)
-	return
-}
-
-// FromDirectory loads gilbert.yaml from specified directory
-func FromDirectory(dir string) (m *Manifest, err error) {
-	location := filepath.Join(dir, FileName)
-	data, err := ioutil.ReadFile(location)
-	if err != nil {
-		return nil, fmt.Errorf("manifest file not found (%s) at %s", FileName, dir)
-	}
-
-	m, err = UnmarshalManifest(data)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse manifest file:\n  %v", err)
-	}
-
-	m.location = location
-	return m, nil
 }

--- a/manifest/file.go
+++ b/manifest/file.go
@@ -37,3 +37,37 @@ type Manifest struct {
 func (m *Manifest) Location() string {
 	return m.location
 }
+
+func (m *Manifest) includeParent(parent *Manifest) {
+	m.Vars = m.Vars.AppendNew(parent.Vars)
+
+	// Copy mixins
+	for k, mx := range parent.Mixins {
+		// Skip if mixin with the same name defined in parent
+		if _, ok := m.Mixins[k]; ok {
+			continue
+		}
+
+		if m.Mixins == nil {
+			m.Mixins = make(Mixins)
+		}
+
+		m.Mixins[k] = make(Mixin, 0, len(mx))
+		copy(mx, m.Mixins[k])
+	}
+
+	// Copy tasks
+	for k, mx := range parent.Tasks {
+		// Skip if mixin with the same name defined in parent
+		if _, ok := m.Tasks[k]; ok {
+			continue
+		}
+
+		if m.Tasks == nil {
+			m.Tasks = make(TaskSet)
+		}
+
+		m.Tasks[k] = make(Task, 0, len(mx))
+		copy(mx, m.Tasks[k])
+	}
+}

--- a/manifest/file.go
+++ b/manifest/file.go
@@ -41,33 +41,35 @@ func (m *Manifest) Location() string {
 func (m *Manifest) includeParent(parent *Manifest) {
 	m.Vars = m.Vars.AppendNew(parent.Vars)
 
-	// Copy mixins
-	for k, mx := range parent.Mixins {
-		// Skip if mixin with the same name defined in parent
-		if _, ok := m.Mixins[k]; ok {
-			continue
-		}
-
+	if len(parent.Mixins) > 0 {
 		if m.Mixins == nil {
 			m.Mixins = make(Mixins)
 		}
 
-		m.Mixins[k] = make(Mixin, 0, len(mx))
-		copy(mx, m.Mixins[k])
+		// Copy mixins
+		for k, mx := range parent.Mixins {
+			// Skip if mixin with the same name defined in parent
+			if _, ok := m.Mixins[k]; ok {
+				continue
+			}
+
+			m.Mixins[k] = append(m.Mixins[k], mx...)
+		}
 	}
 
-	// Copy tasks
-	for k, mx := range parent.Tasks {
-		// Skip if mixin with the same name defined in parent
-		if _, ok := m.Tasks[k]; ok {
-			continue
-		}
-
+	if len(parent.Tasks) > 0 {
 		if m.Tasks == nil {
 			m.Tasks = make(TaskSet)
 		}
 
-		m.Tasks[k] = make(Task, 0, len(mx))
-		copy(mx, m.Tasks[k])
+		// Copy tasks
+		for k, mx := range parent.Tasks {
+			// Skip if mixin with the same name defined in parent
+			if _, ok := m.Tasks[k]; ok {
+				continue
+			}
+
+			m.Tasks[k] = append(m.Tasks[k], mx...)
+		}
 	}
 }

--- a/manifest/imports.go
+++ b/manifest/imports.go
@@ -1,0 +1,143 @@
+package manifest
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"sort"
+)
+
+const errImportMsg = "cannot read file '%s' imported by '%s', %s"
+
+type leafsGroup map[int][]*importNode
+
+type importNode struct {
+	parent   *importNode
+	manifest *Manifest
+	path     string
+	level    int
+	imports  []*importNode
+}
+
+func (i *importNode) mergeWithParent() {
+	if i.parent == nil {
+		return
+	}
+
+	i.parent.manifest.includeParent(i.manifest)
+}
+
+func (i *importNode) mergeChildren() {
+	for _, child := range i.imports {
+		i.manifest.includeParent(child.manifest)
+	}
+}
+
+type importTree struct {
+	root  *importNode
+	leafs []*importNode
+	depth int
+}
+
+func newImportTree(m *Manifest) *importTree {
+	return &importTree{
+		root: importNodeFromManifest(m),
+	}
+}
+
+func importNodeFromManifest(m *Manifest) *importNode {
+	return &importNode{
+		manifest: m,
+		path:     filepath.Dir(m.location),
+		imports:  make([]*importNode, 0, len(m.Imports)),
+	}
+}
+
+func (t *importTree) result() Manifest {
+	r := *t.root.manifest
+	t.root = nil
+	t.leafs = nil
+	return r
+}
+
+// shrinkWrapImports merges all graph nodes with their parents until it gets to the root
+func (t *importTree) shrinkWrapImports(leafs leafsGroup) {
+	// Iterate over each leafs layer from the end
+	for lvl := t.depth; lvl > 0; lvl-- {
+		// Merge each layer with parent
+		for _, leaf := range leafs[lvl] {
+			if leaf.parent != nil {
+				leaf.parent.mergeChildren()
+			}
+		}
+	}
+}
+
+// resolveImports resolves imports and applies them on the root manifest
+func (t *importTree) resolveImports() error {
+	if err := t.buildImportsTree(t.root); err != nil {
+		return err
+	}
+
+	// Sort leafs by level desc (optional)
+	sort.Slice(t.leafs, func(i, j int) bool {
+		return t.leafs[i].level > t.leafs[j].level
+	})
+
+	// group leafs by level
+	leafs := make(leafsGroup)
+	for _, leaf := range t.leafs {
+		if leafs[leaf.level] == nil {
+			// init slice if empty
+			leafs[leaf.level] = make([]*importNode, 0)
+		}
+
+		leafs[leaf.level] = append(leafs[leaf.level], leaf)
+	}
+
+	t.shrinkWrapImports(leafs)
+	return nil
+}
+
+// buildImportsTree resolves all imported files by the main root into import graph
+func (t *importTree) buildImportsTree(n *importNode) error {
+	nextLevel := n.level + 1
+
+	// Increase global depth state
+	if t.depth < nextLevel {
+		t.depth = nextLevel
+	}
+
+	for _, importFile := range n.manifest.Imports {
+		// Join path since import path based on parent file location
+		filePath := filepath.Join(n.path, importFile)
+		data, err := ioutil.ReadFile(filePath)
+		if err != nil {
+			return fmt.Errorf(errImportMsg, importFile, n.manifest.location, err)
+		}
+
+		yml, err := UnmarshalManifest(data)
+		if err != nil {
+			return fmt.Errorf(errImportMsg, importFile, n.manifest.location, err)
+		}
+
+		yml.location = filePath
+		node := importNodeFromManifest(yml)
+		node.parent = n
+		node.level = nextLevel
+
+		// Process child imports if has one at least
+		if len(yml.Imports) > 0 {
+			if err = t.buildImportsTree(node); err != nil {
+				return fmt.Errorf("cannot resolve imports of '%s': %s", yml.location, err)
+			}
+		} else {
+			// If node has no children, mark as leaf
+			t.leafs = append(t.leafs, node)
+		}
+
+		n.imports = append(n.imports, node)
+	}
+
+	return nil
+}

--- a/manifest/imports_test.go
+++ b/manifest/imports_test.go
@@ -25,6 +25,9 @@ func TestLoadManifest(t *testing.T) {
 			},
 		},
 		Tasks: TaskSet{
+			"build": Task{
+				Job{PluginName: "build"},
+			},
 			"b": Task{
 				Job{PluginName: "shell"},
 			},

--- a/manifest/imports_test.go
+++ b/manifest/imports_test.go
@@ -3,28 +3,10 @@ package manifest
 import (
 	"github.com/stretchr/testify/assert"
 	"github.com/x1unix/gilbert/scope"
-	"io/ioutil"
 	"testing"
 )
 
 const testFile = "./testdata/a.yaml"
-
-func testManifest(t *testing.T) *Manifest {
-	data, err := ioutil.ReadFile(testFile)
-	if err != nil {
-		t.Fatalf("test manifest file not found at %s", testFile)
-		return nil
-	}
-
-	m, err := UnmarshalManifest(data)
-	if err != nil {
-		t.Fatalf("failed to parse manifest file:\n  %v", err)
-		return nil
-	}
-
-	m.location = testFile
-	return m
-}
 
 func TestImportResolver_BuildTree(t *testing.T) {
 	expected := Manifest{

--- a/manifest/imports_test.go
+++ b/manifest/imports_test.go
@@ -28,13 +28,19 @@ func testManifest(t *testing.T) *Manifest {
 
 func TestImportResolver_BuildTree(t *testing.T) {
 	expected := Manifest{
-		Version: "1.0",
+		Version:  "1.0",
+		location: "./testdata/a.yaml",
 		Imports: []string{
 			"./include/b.yaml",
 			"./include/c.yaml",
 		},
 		Vars: scope.Vars{
 			"b": "b0",
+		},
+		Mixins: Mixins{
+			"b11mx": Mixin{
+				Job{PluginName: "build"},
+			},
 		},
 		Tasks: TaskSet{
 			"b": Task{

--- a/manifest/imports_test.go
+++ b/manifest/imports_test.go
@@ -8,7 +8,7 @@ import (
 
 const testFile = "./testdata/a.yaml"
 
-func TestImportResolver_BuildTree(t *testing.T) {
+func TestLoadManifest(t *testing.T) {
 	expected := Manifest{
 		Version:  "1.0",
 		location: "./testdata/a.yaml",

--- a/manifest/imports_test.go
+++ b/manifest/imports_test.go
@@ -1,0 +1,64 @@
+package manifest
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/x1unix/gilbert/scope"
+	"io/ioutil"
+	"testing"
+)
+
+const testFile = "./testdata/a.yaml"
+
+func testManifest(t *testing.T) *Manifest {
+	data, err := ioutil.ReadFile(testFile)
+	if err != nil {
+		t.Fatalf("test manifest file not found at %s", testFile)
+		return nil
+	}
+
+	m, err := UnmarshalManifest(data)
+	if err != nil {
+		t.Fatalf("failed to parse manifest file:\n  %v", err)
+		return nil
+	}
+
+	m.location = testFile
+	return m
+}
+
+func TestImportResolver_BuildTree(t *testing.T) {
+	expected := Manifest{
+		Version: "1.0",
+		Imports: []string{
+			"./include/b.yaml",
+			"./include/c.yaml",
+		},
+		Vars: scope.Vars{
+			"b": "b0",
+		},
+		Tasks: TaskSet{
+			"b": Task{
+				Job{PluginName: "shell"},
+			},
+			"b1": Task{
+				Job{PluginName: "shell"},
+			},
+			"b2": Task{
+				Job{PluginName: "shell"},
+			},
+			"b11": Task{
+				Job{PluginName: "shell"},
+			},
+			"c": Task{
+				Job{PluginName: "shell"},
+			},
+		},
+	}
+
+	m := testManifest(t)
+	tr := newImportTree(m)
+	err := tr.resolveImports()
+	assert.NoError(t, err)
+	result := tr.result()
+	assert.Equal(t, expected, result)
+}

--- a/manifest/imports_test.go
+++ b/manifest/imports_test.go
@@ -61,10 +61,9 @@ func TestImportResolver_BuildTree(t *testing.T) {
 		},
 	}
 
-	m := testManifest(t)
-	tr := newImportTree(m)
-	err := tr.resolveImports()
+	result, err := LoadManifest(testFile)
 	assert.NoError(t, err)
-	result := tr.result()
-	assert.Equal(t, expected, result)
+	if err == nil {
+		assert.Equal(t, expected, *result)
+	}
 }

--- a/manifest/loader.go
+++ b/manifest/loader.go
@@ -1,0 +1,32 @@
+package manifest
+
+import (
+	"fmt"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"path/filepath"
+)
+
+// UnmarshalManifest parses yaml contents into manifest structure
+func UnmarshalManifest(data []byte) (m *Manifest, err error) {
+	m = &Manifest{}
+	err = yaml.Unmarshal(data, m)
+	return
+}
+
+// FromDirectory loads gilbert.yaml from specified directory
+func FromDirectory(dir string) (m *Manifest, err error) {
+	location := filepath.Join(dir, FileName)
+	data, err := ioutil.ReadFile(location)
+	if err != nil {
+		return nil, fmt.Errorf("manifest file not found (%s) at %s", FileName, dir)
+	}
+
+	m, err = UnmarshalManifest(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse manifest file:\n  %v", err)
+	}
+
+	m.location = location
+	return m, nil
+}

--- a/manifest/loader.go
+++ b/manifest/loader.go
@@ -14,19 +14,37 @@ func UnmarshalManifest(data []byte) (m *Manifest, err error) {
 	return
 }
 
-// FromDirectory loads gilbert.yaml from specified directory
-func FromDirectory(dir string) (m *Manifest, err error) {
-	location := filepath.Join(dir, FileName)
-	data, err := ioutil.ReadFile(location)
+// LoadManifest loads manifest from specified path and it's imports
+func LoadManifest(path string) (*Manifest, error) {
+	data, err := ioutil.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("manifest file not found (%s) at %s", FileName, dir)
+		return nil, fmt.Errorf("manifest file not found at '%s'", path)
 	}
 
-	m, err = UnmarshalManifest(data)
+	m, err := UnmarshalManifest(data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse manifest file:\n  %v", err)
 	}
 
-	m.location = location
-	return m, nil
+	m.location = path
+
+	// Return as-is if no imports declared
+	if len(m.Imports) == 0 {
+		return m, nil
+	}
+
+	// Load imports
+	tree := newImportTree(m)
+	if err := tree.resolveImports(); err != nil {
+		return nil, fmt.Errorf("failed to resolve imports in manifest file - %s", err)
+	}
+
+	result := tree.result()
+	return &result, nil
+}
+
+// FromDirectory loads gilbert.yaml from specified directory
+func FromDirectory(dir string) (m *Manifest, err error) {
+	location := filepath.Join(dir, FileName)
+	return LoadManifest(location)
 }

--- a/manifest/testdata/a.yaml
+++ b/manifest/testdata/a.yaml
@@ -1,0 +1,8 @@
+version: 1.0
+imports:
+  - ./include/b.yaml
+  - ./include/c.yaml
+
+tasks:
+  foo:
+    - plugin: shell

--- a/manifest/testdata/a.yaml
+++ b/manifest/testdata/a.yaml
@@ -2,7 +2,3 @@ version: 1.0
 imports:
   - ./include/b.yaml
   - ./include/c.yaml
-
-tasks:
-  foo:
-    - plugin: shell

--- a/manifest/testdata/a.yaml
+++ b/manifest/testdata/a.yaml
@@ -2,3 +2,6 @@ version: 1.0
 imports:
   - ./include/b.yaml
   - ./include/c.yaml
+tasks:
+  build:
+    - plugin: build

--- a/manifest/testdata/include/b.yaml
+++ b/manifest/testdata/include/b.yaml
@@ -1,0 +1,7 @@
+version: 1.0
+imports:
+  - ./b1.yaml
+  - ./b2.yaml
+tasks:
+  bar:
+    - plugin: shell

--- a/manifest/testdata/include/b.yaml
+++ b/manifest/testdata/include/b.yaml
@@ -2,6 +2,8 @@ version: 1.0
 imports:
   - ./b1.yaml
   - ./b2.yaml
+vars:
+  b: b0
 tasks:
-  bar:
+  b:
     - plugin: shell

--- a/manifest/testdata/include/b1.yaml
+++ b/manifest/testdata/include/b1.yaml
@@ -1,7 +1,8 @@
 version: 1.0
 imports:
   - ./b11.yaml
-
+vars:
+  b: b1
 tasks:
   b1:
     - plugin: shell

--- a/manifest/testdata/include/b1.yaml
+++ b/manifest/testdata/include/b1.yaml
@@ -1,0 +1,7 @@
+version: 1.0
+imports:
+  - ./b11.yaml
+
+tasks:
+  b1:
+    - plugin: shell

--- a/manifest/testdata/include/b11.yaml
+++ b/manifest/testdata/include/b11.yaml
@@ -1,0 +1,5 @@
+version: 1.0
+
+tasks:
+  b11:
+    - plugin: shell

--- a/manifest/testdata/include/b11.yaml
+++ b/manifest/testdata/include/b11.yaml
@@ -2,6 +2,10 @@ version: 1.0
 vars:
   b: b11
 
+mixins:
+  b11mx:
+    - plugin: build
+
 tasks:
   b11:
     - plugin: shell

--- a/manifest/testdata/include/b11.yaml
+++ b/manifest/testdata/include/b11.yaml
@@ -1,4 +1,6 @@
 version: 1.0
+vars:
+  b: b11
 
 tasks:
   b11:

--- a/manifest/testdata/include/b2.yaml
+++ b/manifest/testdata/include/b2.yaml
@@ -1,0 +1,5 @@
+version: 1.0
+
+tasks:
+  foo:
+    - plugin: shell

--- a/manifest/testdata/include/b2.yaml
+++ b/manifest/testdata/include/b2.yaml
@@ -1,5 +1,5 @@
 version: 1.0
 
 tasks:
-  foo:
+  b2:
     - plugin: shell

--- a/manifest/testdata/include/c.yaml
+++ b/manifest/testdata/include/c.yaml
@@ -1,0 +1,5 @@
+version: 1.0
+
+tasks:
+  c:
+    - plugin: shell

--- a/scope/context.go
+++ b/scope/context.go
@@ -26,6 +26,27 @@ func (v Vars) Append(newVars Vars) (out Vars) {
 	return out
 }
 
+// AppendNew does the same as Append but doesn't overwrite existing values
+func (v Vars) AppendNew(newVars Vars) (out Vars) {
+	if v == nil {
+		return newVars.Clone()
+	}
+
+	out = v.Clone()
+	if newVars == nil || len(newVars) == 0 {
+		return out
+	}
+
+	for k, val := range newVars {
+		if _, ok := out[k]; ok {
+			continue
+		}
+		out[k] = val
+	}
+
+	return out
+}
+
 // Clone creates a copy of variables map
 func (v Vars) Clone() (out Vars) {
 	out = make(Vars, len(v))


### PR DESCRIPTION
## Changelog

### Manifest

#### Imports

Added feature for importing external *yaml* files into `gilbert.yaml`.
Imported file should share the same schematics as original manifest.

**Example:**
```yaml
version: 1.0
imports:
  - ./foo/bar.yaml
  - ./foo.yaml

...
```