### PR TITLE
Fix: empty coverage report

### DIFF
--- a/actions/cover/action.go
+++ b/actions/cover/action.go
@@ -64,15 +64,21 @@ func (a *Action) Call(ctx sdk.JobContextAccessor, r sdk.JobRunner) (err error) {
 }
 
 func (a *Action) printReport(ctx sdk.JobContextAccessor, r *profile.Report) {
-	ctx.Log().Info("Coverage report:")
-	var str string
-	if a.params.FullReport {
-		str = r.FormatFull()
+	if r.Total <= 0 {
+		ctx.Log().Warnf("No test files found in packages")
 	} else {
-		str = r.FormatSimple()
+		// Print coverage report only if any data present
+		ctx.Log().Info("Coverage report:")
+		var str string
+		if a.params.FullReport {
+			str = r.FormatFull()
+		} else {
+			str = r.FormatSimple()
+		}
+
+		_, _ = ctx.Log().Write([]byte(str))
 	}
 
-	_, _ = ctx.Log().Write([]byte(str))
 	ctx.Log().Infof("Total coverage: %.2f%%", r.Percentage())
 }
 

--- a/actions/cover/profile/report.go
+++ b/actions/cover/profile/report.go
@@ -18,6 +18,9 @@ type Coverage struct {
 
 // Percentage gets coverage in percents
 func (c *Coverage) Percentage() float64 {
+	if c.Reached == 0 {
+		return 0
+	}
 	return float64(c.Reached*100) / float64(c.Total)
 }
 


### PR DESCRIPTION
https://github.com/go-gilbert/gilbert/issues/43: Fixes coverage report display when specified packages have no tests