### PR TITLE
cover: sort coverage report

### DIFF
--- a/actions/cover/action.go
+++ b/actions/cover/action.go
@@ -67,13 +67,15 @@ func (a *Action) printReport(ctx sdk.JobContextAccessor, r *profile.Report) {
 	if r.Total <= 0 {
 		ctx.Log().Warnf("No test files found in packages")
 	} else {
+		prop, desc := a.params.Sort.By, a.params.Sort.Desc
+
 		// Print coverage report only if any data present
 		ctx.Log().Info("Coverage report:")
 		var str string
 		if a.params.FullReport {
-			str = r.FormatFull()
+			str = r.FormatFull(prop, desc)
 		} else {
-			str = r.FormatSimple()
+			str = r.FormatSimple(prop, desc)
 		}
 
 		_, _ = ctx.Log().Write([]byte(str))

--- a/actions/cover/cover.go
+++ b/actions/cover/cover.go
@@ -17,8 +17,8 @@ func NewAction(scope sdk.ScopeAccessor, params sdk.ActionParams) (sdk.ActionHand
 		return nil, err
 	}
 
-	if p.Threshold > 100 || p.Threshold < 0 {
-		return nil, fmt.Errorf("coverage threshold should be between 0 and 100 (got %f)", p.Threshold)
+	if err := p.validate(); err != nil {
+		return nil, err
 	}
 
 	f, err := ioutil.TempFile(os.TempDir(), coverFilePattern)

--- a/actions/cover/params.go
+++ b/actions/cover/params.go
@@ -11,7 +11,6 @@ const (
 
 type params struct {
 	Threshold  float64  `mapstructure:"threshold"`
-	SumBy      string   `mapstructure:"sumBy"`
 	Report     bool     `mapstructure:"reportCoverage"`
 	FullReport bool     `mapstructure:"fullReport"`
 	Packages   []string `mapstructure:"packages"`
@@ -20,7 +19,6 @@ type params struct {
 func newParams() params {
 	return params{
 		Threshold: 0.0,
-		SumBy:     sumByStatements,
 		Report:    false,
 	}
 }

--- a/actions/cover/params.go
+++ b/actions/cover/params.go
@@ -1,6 +1,10 @@
 package cover
 
-import "github.com/go-gilbert/gilbert/actions/cover/profile"
+import (
+	"fmt"
+
+	"github.com/go-gilbert/gilbert/actions/cover/profile"
+)
 
 // toolArgsPrefixSize is prefix args count for 'go tool cover' command
 //
@@ -13,6 +17,18 @@ type params struct {
 	FullReport bool      `mapstructure:"fullReport"`
 	Packages   []string  `mapstructure:"packages"`
 	Sort       sortParam `mapstructure:"sort"`
+}
+
+func (p *params) validate() error {
+	if p.Threshold > 100 || p.Threshold < 0 {
+		return fmt.Errorf("coverage threshold should be between 0 and 100 (got %f)", p.Threshold)
+	}
+
+	if p.Sort.By != profile.ByName && p.Sort.By != profile.ByCoverage {
+		return fmt.Errorf("unsupported sort key '%s' (expected %s or %s)", p.Sort.By, profile.ByCoverage, profile.ByName)
+	}
+
+	return nil
 }
 
 type sortParam struct {

--- a/actions/cover/params.go
+++ b/actions/cover/params.go
@@ -1,24 +1,32 @@
 package cover
 
+import "github.com/go-gilbert/gilbert/actions/cover/profile"
+
 // toolArgsPrefixSize is prefix args count for 'go tool cover' command
 //
 // go test -coverprofile=/tmp/cover ./services/foo ./services/bar./services/baz
 const toolArgsPrefixSize = 2
 
-const (
-	sumByStatements = "statements"
-)
-
 type params struct {
-	Threshold  float64  `mapstructure:"threshold"`
-	Report     bool     `mapstructure:"reportCoverage"`
-	FullReport bool     `mapstructure:"fullReport"`
-	Packages   []string `mapstructure:"packages"`
+	Threshold  float64   `mapstructure:"threshold"`
+	Report     bool      `mapstructure:"reportCoverage"`
+	FullReport bool      `mapstructure:"fullReport"`
+	Packages   []string  `mapstructure:"packages"`
+	Sort       sortParam `mapstructure:"sort"`
+}
+
+type sortParam struct {
+	By   string `mapstructure:"by"`
+	Desc bool   `mapstructure:"desc"`
 }
 
 func newParams() params {
 	return params{
 		Threshold: 0.0,
 		Report:    false,
+		Sort: sortParam{
+			By:   profile.ByCoverage,
+			Desc: true,
+		},
 	}
 }

--- a/actions/cover/params_test.go
+++ b/actions/cover/params_test.go
@@ -1,0 +1,52 @@
+package cover
+
+import (
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+func TestParamsValidate(t *testing.T) {
+	cases := map[string]struct {
+		p   params
+		err string
+	}{
+		"validate threshold below 0": {
+			err: "coverage threshold should be between 0 and 100",
+			p: params{
+				Threshold: -1,
+			},
+		},
+		"validate threshold above 100": {
+			err: "coverage threshold should be between 0 and 100",
+			p: params{
+				Threshold: 101,
+			},
+		},
+		"validate sort type": {
+			err: "unsupported sort key",
+			p: params{
+				Threshold: 10,
+				Sort:      sortParam{},
+			},
+		},
+	}
+
+	for n, c := range cases {
+		t.Run("should "+n, func(t *testing.T) {
+			err := c.p.validate()
+			if c.err == "" {
+				assert.NoError(t, err)
+				return
+			}
+
+			if err == nil {
+				t.Fatal("expected error message but got nil")
+			}
+
+			if got := err.Error(); !strings.Contains(got, c.err) {
+				t.Fatalf("error '%s' should contain '%s'", got, c.err)
+			}
+		})
+	}
+}

--- a/actions/cover/profile/report.go
+++ b/actions/cover/profile/report.go
@@ -30,7 +30,7 @@ func (p Packages) Sort(by string, asc bool) []string {
 		sortFn = byName
 	}
 
-	s := &packageSorter{asc: asc, keys: keys, by: sortFn}
+	s := &mapSorter{asc: asc, keys: keys, by: sortFn}
 	sort.Sort(s)
 	return keys
 }
@@ -100,6 +100,30 @@ func (r *Report) FormatSimple() string {
 type PackageReport struct {
 	Coverage
 	Functions map[string]*Coverage
+}
+
+func (p *PackageReport) names() []string {
+	out := make([]string, 0, len(p.Functions))
+	for k := range p.Functions {
+		out = append(out, k)
+	}
+
+	return out
+}
+
+// Sort sorts package report data by specified criteria
+func (p *PackageReport) Sort(by string, asc bool) []string {
+	keys := p.names()
+	var sortFn sortSelector
+	if by == ByCoverage {
+		sortFn = reportByPercentage(p)
+	} else {
+		sortFn = byName
+	}
+
+	s := &mapSorter{asc: asc, keys: keys, by: sortFn}
+	sort.Sort(s)
+	return keys
 }
 
 // Create creates a new report from GoCov profile

--- a/actions/cover/profile/report.go
+++ b/actions/cover/profile/report.go
@@ -4,8 +4,36 @@ import (
 	"fmt"
 	"github.com/axw/gocov"
 	"github.com/axw/gocov/gocovutil"
+	"sort"
 	"strings"
 )
+
+type Packages map[string]*PackageReport
+
+// Names returns a slice of package names
+func (p Packages) Names() []string {
+	out := make([]string, 0, len(p))
+	for k := range p {
+		out = append(out, k)
+	}
+
+	return out
+}
+
+// Sort sorts packages by specified criteria
+func (p Packages) Sort(by string, asc bool) []string {
+	keys := p.Names()
+	var sortFn sortSelector
+	if by == ByCoverage {
+		sortFn = pkgByPercentage(p)
+	} else {
+		sortFn = byName
+	}
+
+	s := &packageSorter{asc: asc, keys: keys, by: sortFn}
+	sort.Sort(s)
+	return keys
+}
 
 // Coverage is coverage report with total and reached statements count
 type Coverage struct {
@@ -32,7 +60,7 @@ func (c *Coverage) add(cv Coverage) {
 // Report is coverage report from GoCov profile
 type Report struct {
 	Coverage
-	Packages map[string]*PackageReport
+	Packages Packages
 }
 
 // CheckCoverage checks if report satisfies coverage requirements

--- a/actions/cover/profile/report.go
+++ b/actions/cover/profile/report.go
@@ -21,7 +21,7 @@ func (p Packages) Names() []string {
 }
 
 // Sort sorts packages by specified criteria
-func (p Packages) Sort(by string, asc bool) []string {
+func (p Packages) Sort(by string, desc bool) []string {
 	keys := p.Names()
 	var sortFn sortSelector
 	if by == ByCoverage {
@@ -30,7 +30,7 @@ func (p Packages) Sort(by string, asc bool) []string {
 		sortFn = byName
 	}
 
-	s := &mapSorter{asc: asc, keys: keys, by: sortFn}
+	s := &mapSorter{desc: desc, keys: keys, by: sortFn}
 	sort.Sort(s)
 	return keys
 }
@@ -74,11 +74,16 @@ func (r *Report) CheckCoverage(threshold float64) error {
 }
 
 // FormatFull returns detailed report
-func (r *Report) FormatFull() string {
+func (r *Report) FormatFull(orderProp string, desc bool) string {
 	b := strings.Builder{}
-	for pkgName, pkg := range r.Packages {
+	pkgNames := r.Packages.Sort(orderProp, desc)
+	for _, pkgName := range pkgNames {
+		pkg := r.Packages[pkgName]
 		_, _ = fmt.Fprintf(&b, "  Package '%s' - %.2f%%\n", pkgName, pkg.Percentage())
-		for fnName, fn := range pkg.Functions {
+
+		fnNames := pkg.Sort(orderProp, desc)
+		for _, fnName := range fnNames {
+			fn := pkg.Functions[fnName]
 			_, _ = fmt.Fprintf(&b, "    - %s: %.2f%%\n", fnName, fn.Percentage())
 		}
 	}
@@ -87,9 +92,12 @@ func (r *Report) FormatFull() string {
 }
 
 // FormatSimple returns simplified report
-func (r *Report) FormatSimple() string {
+func (r *Report) FormatSimple(orderProp string, desc bool) string {
 	b := strings.Builder{}
-	for pkgName, pkg := range r.Packages {
+
+	pkgNames := r.Packages.Sort(orderProp, desc)
+	for _, pkgName := range pkgNames {
+		pkg := r.Packages[pkgName]
 		_, _ = fmt.Fprintf(&b, "  - %s: %.2f%%\n", pkgName, pkg.Percentage())
 	}
 
@@ -112,7 +120,7 @@ func (p *PackageReport) names() []string {
 }
 
 // Sort sorts package report data by specified criteria
-func (p *PackageReport) Sort(by string, asc bool) []string {
+func (p *PackageReport) Sort(by string, desc bool) []string {
 	keys := p.names()
 	var sortFn sortSelector
 	if by == ByCoverage {
@@ -121,7 +129,7 @@ func (p *PackageReport) Sort(by string, asc bool) []string {
 		sortFn = byName
 	}
 
-	s := &mapSorter{asc: asc, keys: keys, by: sortFn}
+	s := &mapSorter{desc: desc, keys: keys, by: sortFn}
 	sort.Sort(s)
 	return keys
 }

--- a/actions/cover/profile/sort.go
+++ b/actions/cover/profile/sort.go
@@ -22,6 +22,18 @@ func pkgByPercentage(p Packages) sortSelector {
 	}
 }
 
+func reportByPercentage(p *PackageReport) sortSelector {
+	return func(asc bool, pkg1, pkg2 string) bool {
+		pkg1cover, pkg2cover := p.Functions[pkg1].Percentage(), p.Functions[pkg2].Percentage()
+
+		if asc {
+			return pkg1cover < pkg2cover
+		}
+
+		return pkg1cover > pkg2cover
+	}
+}
+
 func byName(asc bool, pkg1, pkg2 string) bool {
 	if asc {
 		return pkg1 < pkg2
@@ -30,20 +42,20 @@ func byName(asc bool, pkg1, pkg2 string) bool {
 	return pkg1 > pkg2
 }
 
-type packageSorter struct {
+type mapSorter struct {
 	asc  bool
 	keys []string
 	by   sortSelector
 }
 
-func (p *packageSorter) Len() int {
+func (p *mapSorter) Len() int {
 	return len(p.keys)
 }
 
-func (p *packageSorter) Swap(i, j int) {
+func (p *mapSorter) Swap(i, j int) {
 	p.keys[i], p.keys[j] = p.keys[j], p.keys[i]
 }
 
-func (p *packageSorter) Less(i, j int) bool {
+func (p *mapSorter) Less(i, j int) bool {
 	return p.by(p.asc, p.keys[i], p.keys[j])
 }

--- a/actions/cover/profile/sort.go
+++ b/actions/cover/profile/sort.go
@@ -1,0 +1,49 @@
+package profile
+
+const (
+	// ByName means sort by name
+	ByName = "name"
+
+	// ByCoverage means sort by coverage percentage
+	ByCoverage = "coverage"
+)
+
+type sortSelector func(asc bool, k1, k2 string) bool
+
+func pkgByPercentage(p Packages) sortSelector {
+	return func(asc bool, pkg1, pkg2 string) bool {
+		pkg1cover, pkg2cover := p[pkg1].Percentage(), p[pkg2].Percentage()
+
+		if asc {
+			return pkg1cover < pkg2cover
+		}
+
+		return pkg1cover > pkg2cover
+	}
+}
+
+func byName(asc bool, pkg1, pkg2 string) bool {
+	if asc {
+		return pkg1 < pkg2
+	}
+
+	return pkg1 > pkg2
+}
+
+type packageSorter struct {
+	asc  bool
+	keys []string
+	by   sortSelector
+}
+
+func (p *packageSorter) Len() int {
+	return len(p.keys)
+}
+
+func (p *packageSorter) Swap(i, j int) {
+	p.keys[i], p.keys[j] = p.keys[j], p.keys[i]
+}
+
+func (p *packageSorter) Less(i, j int) bool {
+	return p.by(p.asc, p.keys[i], p.keys[j])
+}

--- a/actions/cover/profile/sort.go
+++ b/actions/cover/profile/sort.go
@@ -11,39 +11,39 @@ const (
 type sortSelector func(asc bool, k1, k2 string) bool
 
 func pkgByPercentage(p Packages) sortSelector {
-	return func(asc bool, pkg1, pkg2 string) bool {
+	return func(desc bool, pkg1, pkg2 string) bool {
 		pkg1cover, pkg2cover := p[pkg1].Percentage(), p[pkg2].Percentage()
 
-		if asc {
-			return pkg1cover < pkg2cover
+		if desc {
+			return pkg1cover > pkg2cover
 		}
 
-		return pkg1cover > pkg2cover
+		return pkg1cover < pkg2cover
 	}
 }
 
 func reportByPercentage(p *PackageReport) sortSelector {
-	return func(asc bool, pkg1, pkg2 string) bool {
+	return func(desc bool, pkg1, pkg2 string) bool {
 		pkg1cover, pkg2cover := p.Functions[pkg1].Percentage(), p.Functions[pkg2].Percentage()
 
-		if asc {
-			return pkg1cover < pkg2cover
+		if desc {
+			return pkg1cover > pkg2cover
 		}
 
-		return pkg1cover > pkg2cover
+		return pkg1cover < pkg2cover
 	}
 }
 
-func byName(asc bool, pkg1, pkg2 string) bool {
-	if asc {
-		return pkg1 < pkg2
+func byName(desc bool, pkg1, pkg2 string) bool {
+	if desc {
+		return pkg1 > pkg2
 	}
 
-	return pkg1 > pkg2
+	return pkg1 < pkg2
 }
 
 type mapSorter struct {
-	asc  bool
+	desc bool
 	keys []string
 	by   sortSelector
 }
@@ -57,5 +57,5 @@ func (p *mapSorter) Swap(i, j int) {
 }
 
 func (p *mapSorter) Less(i, j int) bool {
-	return p.by(p.asc, p.keys[i], p.keys[j])
+	return p.by(p.desc, p.keys[i], p.keys[j])
 }

--- a/actions/cover/profile/sort_test.go
+++ b/actions/cover/profile/sort_test.go
@@ -1,23 +1,15 @@
 package profile
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func cov2report(cov int) *PackageReport {
 	return &PackageReport{
 		Coverage: Coverage{Total: 100, Reached: cov},
 	}
-}
-
-func strReverse(in []string) []string {
-	out := make([]string, 0, len(in))
-	for k := range in {
-		out = append(out, in[k])
-	}
-
-	return out
 }
 
 func TestPackages_Sort(t *testing.T) {
@@ -56,6 +48,54 @@ func TestPackages_Sort(t *testing.T) {
 
 	for sortBy, c := range cases {
 		t.Run("sort by "+sortBy+"(asc)", func(t *testing.T) {
+			result := c.input.Sort(sortBy, c.asc)
+			assert.Equal(t, c.expect, result)
+		})
+	}
+}
+
+func pkgReportCov(fns map[string]int) *PackageReport {
+	out := &PackageReport{
+		Functions: make(map[string]*Coverage, len(fns)),
+	}
+
+	for c, i := range fns {
+		out.Functions[c] = &Coverage{Total: 100, Reached: i}
+	}
+
+	return out
+}
+
+func TestReport_Sort(t *testing.T) {
+	cases := map[string]struct {
+		asc    bool
+		input  *PackageReport
+		expect []string
+	}{
+		ByName: {
+			asc: true,
+			input: pkgReportCov(map[string]int{
+				"a": 0,
+				"c": 10,
+				"d": 60,
+				"b": 30,
+			}),
+			expect: []string{"a", "b", "c", "d"},
+		},
+		ByCoverage: {
+			asc: false,
+			input: pkgReportCov(map[string]int{
+				"a": 0,
+				"c": 10,
+				"d": 60,
+				"b": 30,
+			}),
+			expect: []string{"d", "b", "c", "a"},
+		},
+	}
+
+	for sortBy, c := range cases {
+		t.Run("sort by "+sortBy, func(t *testing.T) {
 			result := c.input.Sort(sortBy, c.asc)
 			assert.Equal(t, c.expect, result)
 		})

--- a/actions/cover/profile/sort_test.go
+++ b/actions/cover/profile/sort_test.go
@@ -1,0 +1,63 @@
+package profile
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func cov2report(cov int) *PackageReport {
+	return &PackageReport{
+		Coverage: Coverage{Total: 100, Reached: cov},
+	}
+}
+
+func strReverse(in []string) []string {
+	out := make([]string, 0, len(in))
+	for k := range in {
+		out = append(out, in[k])
+	}
+
+	return out
+}
+
+func TestPackages_Sort(t *testing.T) {
+	cases := map[string]struct {
+		asc    bool
+		input  Packages
+		expect []string
+	}{
+		ByName: {
+			asc: true,
+			input: Packages{
+				"github.com/go-gilbert/gilbert/bcc/aaa": nil,
+				"github.com/go-gilbert/gilbert/fca":     nil,
+				"github.com/go-gilbert/gilbert/bcc":     nil,
+				"github.com/go-gilbert/gilbert/abc":     nil,
+			},
+			expect: []string{
+				"github.com/go-gilbert/gilbert/abc",
+				"github.com/go-gilbert/gilbert/bcc",
+				"github.com/go-gilbert/gilbert/bcc/aaa",
+				"github.com/go-gilbert/gilbert/fca",
+			},
+		},
+		ByCoverage: {
+			asc: false,
+			input: Packages{
+				"c": cov2report(30),
+				"d": cov2report(25),
+				"b": cov2report(78),
+				"e": cov2report(0),
+				"a": cov2report(100),
+			},
+			expect: []string{"a", "b", "c", "d", "e"},
+		},
+	}
+
+	for sortBy, c := range cases {
+		t.Run("sort by "+sortBy+"(asc)", func(t *testing.T) {
+			result := c.input.Sort(sortBy, c.asc)
+			assert.Equal(t, c.expect, result)
+		})
+	}
+}

--- a/actions/cover/profile/sort_test.go
+++ b/actions/cover/profile/sort_test.go
@@ -14,12 +14,12 @@ func cov2report(cov int) *PackageReport {
 
 func TestPackages_Sort(t *testing.T) {
 	cases := map[string]struct {
-		asc    bool
+		desc   bool
 		input  Packages
 		expect []string
 	}{
 		ByName: {
-			asc: true,
+			desc: false,
 			input: Packages{
 				"github.com/go-gilbert/gilbert/bcc/aaa": nil,
 				"github.com/go-gilbert/gilbert/fca":     nil,
@@ -34,7 +34,7 @@ func TestPackages_Sort(t *testing.T) {
 			},
 		},
 		ByCoverage: {
-			asc: false,
+			desc: true,
 			input: Packages{
 				"c": cov2report(30),
 				"d": cov2report(25),
@@ -47,8 +47,8 @@ func TestPackages_Sort(t *testing.T) {
 	}
 
 	for sortBy, c := range cases {
-		t.Run("sort by "+sortBy+"(asc)", func(t *testing.T) {
-			result := c.input.Sort(sortBy, c.asc)
+		t.Run("sort by "+sortBy+"(desc)", func(t *testing.T) {
+			result := c.input.Sort(sortBy, c.desc)
 			assert.Equal(t, c.expect, result)
 		})
 	}
@@ -68,12 +68,12 @@ func pkgReportCov(fns map[string]int) *PackageReport {
 
 func TestReport_Sort(t *testing.T) {
 	cases := map[string]struct {
-		asc    bool
+		desc   bool
 		input  *PackageReport
 		expect []string
 	}{
 		ByName: {
-			asc: true,
+			desc: false,
 			input: pkgReportCov(map[string]int{
 				"a": 0,
 				"c": 10,
@@ -83,7 +83,7 @@ func TestReport_Sort(t *testing.T) {
 			expect: []string{"a", "b", "c", "d"},
 		},
 		ByCoverage: {
-			asc: false,
+			desc: true,
 			input: pkgReportCov(map[string]int{
 				"a": 0,
 				"c": 10,
@@ -96,7 +96,7 @@ func TestReport_Sort(t *testing.T) {
 
 	for sortBy, c := range cases {
 		t.Run("sort by "+sortBy, func(t *testing.T) {
-			result := c.input.Sort(sortBy, c.asc)
+			result := c.input.Sort(sortBy, c.desc)
 			assert.Equal(t, c.expect, result)
 		})
 	}

--- a/gilbert.yaml
+++ b/gilbert.yaml
@@ -36,7 +36,7 @@ tasks:
       threshold: 60
       sumBy: 'statements'
       reportCoverage: true
-      fullReport: false
+      fullReport: true
       packages:
         - ./manifest
         - ./support

--- a/gilbert.yaml
+++ b/gilbert.yaml
@@ -35,11 +35,10 @@ tasks:
     params:
       threshold: 60
       reportCoverage: true
-      fullReport: true
       packages:
         - ./manifest
         - ./support
-        - ./plugins/...
+        - ./actions/...
 
   lint:
     - description: lint

--- a/gilbert.yaml
+++ b/gilbert.yaml
@@ -36,9 +36,7 @@ tasks:
       threshold: 60
       reportCoverage: true
       packages:
-        - ./manifest
-        - ./support
-        - ./actions/...
+        - ./...
 
   lint:
     - description: lint

--- a/gilbert.yaml
+++ b/gilbert.yaml
@@ -34,7 +34,6 @@ tasks:
   - action: cover
     params:
       threshold: 60
-      sumBy: 'statements'
       reportCoverage: true
       fullReport: true
       packages:


### PR DESCRIPTION
Adds coverage report sort feature with `sort` param.

Closes https://github.com/go-gilbert/gilbert/issues/45

**Example**

```yaml
  cover:
  - action: cover
    params:
      threshold: 60
      sort:
        by: 'name'    # accepted values: 'name', 'coverage' 
        desc: false   # sort order
      packages:
        - ./...
```