### PR TITLE
cmd: override variables

### DIFF
--- a/cli/tasks/tasks.go
+++ b/cli/tasks/tasks.go
@@ -3,15 +3,26 @@ package tasks
 import (
 	"context"
 	"fmt"
+	"os"
+	"os/signal"
+	"runtime"
+	"strings"
+
+	"github.com/go-gilbert/gilbert-sdk"
 	"github.com/go-gilbert/gilbert/log"
 	"github.com/go-gilbert/gilbert/manifest"
 	"github.com/go-gilbert/gilbert/plugins"
 	"github.com/go-gilbert/gilbert/runner"
 	"github.com/go-gilbert/gilbert/scope"
 	"github.com/urfave/cli"
-	"os"
-	"os/signal"
-	"runtime"
+)
+
+const (
+	// OverrideVarFlag is flag name for custom variable values
+	OverrideVarFlag = "var"
+
+	varDelimiter = "="
+	paramsCount  = 2
 )
 
 func wrapManifestError(parent error) error {
@@ -51,12 +62,39 @@ func RunTask(c *cli.Context) (err error) {
 	tr.SetContext(ctx, cancelFn)
 	go handleShutdown(cancelFn)
 
-	if err := tr.RunTask(task); err != nil {
+	vars := getOverrideVars(c)
+	if err := tr.RunTask(task, vars); err != nil {
 		return err
 	}
 
 	log.Default.Successf("Task '%s' ran successfully\n", task)
 	return nil
+}
+
+func getOverrideVars(c *cli.Context) sdk.Vars {
+	ss := c.StringSlice(OverrideVarFlag)
+	sLen := len(ss)
+
+	if sLen == 0 {
+		return nil
+	}
+
+	out := make(sdk.Vars, sLen)
+	for _, s := range ss {
+		if s == "" {
+			continue
+		}
+
+		// param=value
+		vals := strings.Split(s, varDelimiter)
+		if len(vals) < paramsCount {
+			continue
+		}
+
+		out[vals[0]] = vals[1]
+	}
+
+	return out
 }
 
 func importProjectPlugins(ctx context.Context, m *manifest.Manifest, cwd string) error {

--- a/cli/tasks/tasks.go
+++ b/cli/tasks/tasks.go
@@ -92,7 +92,10 @@ func getOverrideVars(c *cli.Context) sdk.Vars {
 			continue
 		}
 
-		out[vals[0]] = vals[1]
+		key := strings.TrimSpace(vals[0])
+		val := vals[1]
+		log.Default.Debugf("cmd: set variable '%s' = '%s'", key, val)
+		out[key] = val
 	}
 
 	return out

--- a/cli/tasks/tasks.go
+++ b/cli/tasks/tasks.go
@@ -62,6 +62,7 @@ func RunTask(c *cli.Context) (err error) {
 	tr.SetContext(ctx, cancelFn)
 	go handleShutdown(cancelFn)
 
+	// get variables passed with '--var' flags
 	vars := getOverrideVars(c)
 	if err := tr.RunTask(task, vars); err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -50,6 +50,9 @@ func main() {
 			Before:      bootstrap,
 			Flags: []cli.Flag{
 				verboseFlag,
+				cli.StringSliceFlag{
+					Name: tasks.OverrideVarFlag,
+				},
 			},
 		},
 		{

--- a/manifest/file.go
+++ b/manifest/file.go
@@ -12,7 +12,7 @@ const (
 // Manifest represents manifest file (gilbert.yaml)
 type Manifest struct {
 	// Plugins is plugins import list
-	Plugins []string `yaml:"plugins"`
+	Plugins []string `yaml:"plugins,omitempty"`
 
 	// Version is gilbert file format version
 	Version string `yaml:"version"`

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -44,8 +44,10 @@ func (t *TaskRunner) Stop() {
 	}
 }
 
-// RunTask execute task by name
-func (t *TaskRunner) RunTask(taskName string) (err error) {
+// RunTask execute task by name.
+//
+// "vars" parameter is optional and allows to override job scope values.
+func (t *TaskRunner) RunTask(taskName string, vars sdk.Vars) (err error) {
 	task, ok := t.manifest.Tasks[taskName]
 	if !ok {
 		return fmt.Errorf("task '%s' doesn't exists", taskName)
@@ -92,7 +94,7 @@ func (t *TaskRunner) RunTask(taskName string) (err error) {
 			t.subLogger.Infof("- %s", descr)
 		}
 		var err error
-		ctx := job.NewRunContext(t.context, nil, sl)
+		ctx := job.NewRunContext(t.context, vars, sl)
 
 		if j.Async {
 			tracker.decorateJobContext(ctx)


### PR DESCRIPTION
Adds cmd flag `--var` that allows to set or override job variables:

**Example**

```bash
gilbert run task_name --var var1=value --var var2=value
```

Closes https://github.com/go-gilbert/gilbert/issues/46