### PR TITLE
feat: Signals support

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -30,7 +30,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: go.sum
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6.2.0
+        uses: golangci/golangci-lint-action@v9
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
   test:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,15 +10,15 @@ name: Check Pull Request
 on:
   pull_request:
     paths:
-      - '.github/**'
-      - 'cmd/**'
-      - 'internal/**'
-      - 'pkg/**'
-      - 'go.mod'
-      - 'go.sum'
+      - ".github/**"
+      - "cmd/**"
+      - "internal/**"
+      - "pkg/**"
+      - "go.mod"
+      - "go.sum"
 env:
-  GOLANGCI_LINT_VERSION: "v1.61.0"
-  GO_VERSION: "^1.23.0"
+  GOLANGCI_LINT_VERSION: "v2.12"
+  GO_VERSION: "^1.26.0"
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,2 +1,22 @@
+version: "2"
 run:
   tests: false
+linters:
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/docs/testdata/gilbert.yml
+++ b/docs/testdata/gilbert.yml
@@ -37,19 +37,32 @@ inputs:
 tasks:
   # Task to debug task runner
   test:
+    inputs:
+      # Test message content
+      message:
+        type: string
+
+      # Signal name
+      signal:
+        type: string
+        default: mysignal
+
     steps:
       - action: debug/signal
         with:
-          signal: mysignal
+          signal: ${{inputs.signal}}
         on:
           mysignal:
             - action: debug/echo
               with:
-                message: "message: ${{msg}}"
+                message: "message: ${{inputs.message}}, data: ${{toJSON(event)}}"
           error:
             - action: debug/echo
               with:
                 message: Error happened
+      - action: debug/echo
+        with:
+          message: next
 
   # Build builds application
   build:

--- a/docs/testdata/gilbert.yml
+++ b/docs/testdata/gilbert.yml
@@ -29,17 +29,18 @@ inputs:
     type: date
     optional: true
     dateFormat: "2006-01-02 15:04:05"
-  items:
-    type: list
-    items:
-      type: int
+  # items:
+  #   type: list
+  #   items:
+  #     type: int
 
 tasks:
+  # Task to debug task runner
   test:
     steps:
-      - action: githubMod/actionName
+      - action: debug/signal
         with:
-          key: value
+          signal: value
 
   # Build builds application
   build:
@@ -52,9 +53,9 @@ tasks:
       - action: go/build
         if: ${{inputs.version != "invalid"}}
         timeout: 30s
+        continue-on-error: false
         strategy:
           max-parallel: 2
-          continue-on-error: false
           matrix:
             os: [windows, linux, darwin]
             arch: [amd64, 386, arm64]

--- a/docs/testdata/gilbert.yml
+++ b/docs/testdata/gilbert.yml
@@ -38,9 +38,9 @@ tasks:
   # Task to debug task runner
   test:
     steps:
-      - action: debug/signal
+      - action: debug/echo
         with:
-          signal: value
+          message: hello
 
   # Build builds application
   build:

--- a/docs/testdata/gilbert.yml
+++ b/docs/testdata/gilbert.yml
@@ -38,9 +38,18 @@ tasks:
   # Task to debug task runner
   test:
     steps:
-      - action: debug/echo
+      - action: debug/signal
         with:
-          message: hello
+          signal: mysignal
+        on:
+          mysignal:
+            - action: debug/echo
+              with:
+                message: "message: ${{msg}}"
+          error:
+            - action: debug/echo
+              with:
+                message: Error happened
 
   # Build builds application
   build:

--- a/docs/testdata/gilbert.yml
+++ b/docs/testdata/gilbert.yml
@@ -47,10 +47,15 @@ tasks:
         type: string
         default: mysignal
 
+      # Throw error?
+      fail:
+        type: bool
+
     steps:
       - action: debug/signal
         with:
           signal: ${{inputs.signal}}
+          fail: ${{inputs.fail}}
         on:
           mysignal:
             - action: debug/echo

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -5,7 +5,7 @@
 
 **loader**
 
-- yamlloader: pass indents from *ast.LiteralNode into expr.DocumentInfo
+- yamlloader: pass indents from \*ast.LiteralNode into expr.DocumentInfo
 - yamlloader: check if global input flag is reserved for builtin
 - yamlloader: check if task input flag is reserved for builtin or global
 
@@ -21,13 +21,3 @@
 
 - Support indents in DocumentInfo
 - Consider cel-go as it might support dynamic envs: https://github.com/google/cel-go
-
-**uflag**
-
-- Bug when boolean flag w/o value is near other:
-
-```
-$ ./gilbert.sh run build --items=1,2,3 --release
-
-error: invalid argument "--log-level=debug" for "--release" flag: strconv.ParseBool: parsing "--log-level=debug": invalid syntax
-```

--- a/gilbert.yml
+++ b/gilbert.yml
@@ -18,9 +18,9 @@ tasks:
     steps:
       - action: go/build
         timeout: 30s
+        continue-on-error: false
         strategy:
           max-parallel: 2
-          continue-on-error: false
           matrix:
             os: [windows, linux, darwin]
             arch: [amd64, 386, arm64]

--- a/internal/manifest/file.go
+++ b/internal/manifest/file.go
@@ -1,7 +1,7 @@
 package manifest
 
 const (
-	// FileName is default manifest filename
+	// FileName is default manifest filename.
 	FileName = "gilbert.yaml"
 )
 

--- a/internal/manifest/loader.go
+++ b/internal/manifest/loader.go
@@ -1,7 +1,9 @@
 package manifest
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -55,6 +57,13 @@ func LoadManifest(path string) (*Manifest, error) {
 
 // FromDirectory loads gilbert.yaml from specified directory
 func FromDirectory(dir string) (m *Manifest, err error) {
+	// Both .yaml and .yml are valid extensions.
 	location := filepath.Join(dir, FileName)
+	if _, err := os.Stat(location); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			location = filepath.Join(dir, "gilbert.yml")
+		}
+	}
+
 	return LoadManifest(location)
 }

--- a/internal/v2/actions/debug/actions.go
+++ b/internal/v2/actions/debug/actions.go
@@ -1,0 +1,10 @@
+// Package debug provides actions for debugging the runner.
+package debug
+
+import (
+	"github.com/go-gilbert/gilbert/internal/v2/engine"
+)
+
+var Actions = map[string]engine.ActionHandlerConstructor{
+	"signal": newSignalActionHandler,
+}

--- a/internal/v2/actions/debug/actions.go
+++ b/internal/v2/actions/debug/actions.go
@@ -7,4 +7,5 @@ import (
 
 var Actions = map[string]engine.ActionHandlerConstructor{
 	"signal": newSignalActionHandler,
+	"echo":   newEchoActionHandler,
 }

--- a/internal/v2/actions/debug/echo.go
+++ b/internal/v2/actions/debug/echo.go
@@ -45,7 +45,7 @@ func newEchoActionHandler(ctx context.Context, ref manifest.JobHandlerRef, param
 	return engine.NewHandlerResult(h, diags)
 }
 
-func (h *echoActionHandler) HandleAction(ctx context.Context) error {
+func (h *echoActionHandler) HandleAction(ctx context.Context, emitter engine.SignalEmitter) error {
 	h.logger.Info(h.args.message)
 	return nil
 }

--- a/internal/v2/actions/debug/echo.go
+++ b/internal/v2/actions/debug/echo.go
@@ -1,0 +1,51 @@
+package debug
+
+import (
+	"context"
+	"errors"
+
+	"github.com/go-gilbert/gilbert/internal/v2/engine"
+	"github.com/go-gilbert/gilbert/internal/v2/log"
+	"github.com/go-gilbert/gilbert/internal/v2/manifest"
+
+	. "github.com/go-gilbert/gilbert/internal/v2/manifest/argschema"
+)
+
+var echoSchema = Struct(
+	StringField("message", func(dst *echoArgs, val string) error {
+		if val == "" {
+			return errors.New("message name is required")
+		}
+
+		dst.message = val
+		return nil
+	}).Required(),
+)
+
+type echoArgs struct {
+	message string
+}
+
+type echoActionHandler struct {
+	logger log.Logger
+	args   echoArgs
+}
+
+func newEchoActionHandler(ctx context.Context, ref manifest.JobHandlerRef, params engine.ActionParams) engine.HandlerResult {
+	args, diags := MapArgsToStruct(ctx, params, echoSchema)
+	if diags.HasError() {
+		return engine.NewBadActionParamsResult(ref, diags)
+	}
+
+	h := &echoActionHandler{
+		logger: params.Logger,
+		args:   args,
+	}
+
+	return engine.NewHandlerResult(h, diags)
+}
+
+func (h *echoActionHandler) HandleAction(ctx context.Context) error {
+	h.logger.Info(h.args.message)
+	return nil
+}

--- a/internal/v2/actions/debug/signaltest.go
+++ b/internal/v2/actions/debug/signaltest.go
@@ -1,0 +1,55 @@
+package debug
+
+import (
+	"context"
+	"errors"
+
+	"github.com/go-gilbert/gilbert/internal/v2/engine"
+	"github.com/go-gilbert/gilbert/internal/v2/log"
+	"github.com/go-gilbert/gilbert/internal/v2/manifest"
+
+	. "github.com/go-gilbert/gilbert/internal/v2/manifest/argschema"
+)
+
+var signalSchema = Struct(
+	StringField("signal", func(dst *signalActionArgs, val string) error {
+		if val == "" {
+			return errors.New("signal name is required")
+		}
+
+		dst.signalName = val
+		return nil
+	}).Required(),
+	BoolField("fail", func(dst *signalActionArgs, val bool) error {
+		dst.fail = val
+		return nil
+	}),
+)
+
+type signalActionArgs struct {
+	signalName string
+	fail       bool
+}
+
+type signalActionHandler struct {
+	logger log.Logger
+	args   signalActionArgs
+}
+
+func newSignalActionHandler(ctx context.Context, ref manifest.JobHandlerRef, params engine.ActionParams) engine.HandlerResult {
+	args, diags := MapArgsToStruct(ctx, params, signalSchema)
+	if diags.HasError() {
+		return engine.NewBadActionParamsResult(ref, diags)
+	}
+
+	h := &signalActionHandler{
+		logger: params.Logger,
+		args:   args,
+	}
+
+	return engine.NewHandlerResult(h, diags)
+}
+
+func (h *signalActionHandler) HandleAction(ctx context.Context) error {
+	return errors.New("signals are not implemented")
+}

--- a/internal/v2/actions/debug/signaltest.go
+++ b/internal/v2/actions/debug/signaltest.go
@@ -50,6 +50,10 @@ func newSignalActionHandler(ctx context.Context, ref manifest.JobHandlerRef, par
 	return engine.NewHandlerResult(h, diags)
 }
 
-func (h *signalActionHandler) HandleAction(ctx context.Context) error {
-	return errors.New("signals are not implemented")
+func (h *signalActionHandler) HandleAction(ctx context.Context, emitter engine.SignalEmitter) error {
+	err := emitter.EmitSignal(ctx, h.args.signalName, map[string]any{
+		"message": "test signal",
+	})
+
+	return err
 }

--- a/internal/v2/actions/debug/signaltest.go
+++ b/internal/v2/actions/debug/signaltest.go
@@ -51,6 +51,10 @@ func newSignalActionHandler(ctx context.Context, ref manifest.JobHandlerRef, par
 }
 
 func (h *signalActionHandler) HandleAction(ctx context.Context, emitter engine.SignalEmitter) error {
+	if h.args.fail {
+		return errors.New("test error from action handler")
+	}
+
 	err := emitter.EmitSignal(ctx, h.args.signalName, map[string]any{
 		"message": "test signal",
 	})

--- a/internal/v2/actions/golang/build.go
+++ b/internal/v2/actions/golang/build.go
@@ -39,7 +39,7 @@ func NewBuildActionHandler(ctx context.Context, ref manifest.JobHandlerRef, para
 	return engine.NewHandlerResult(h, diags)
 }
 
-func (b *BuildActionHandler) HandleAction(ctx context.Context) error {
+func (b *BuildActionHandler) HandleAction(ctx context.Context, emitter engine.SignalEmitter) error {
 	argv, err := b.args.commandArgs()
 	if err != nil {
 		return err

--- a/internal/v2/actions/golang/build.go
+++ b/internal/v2/actions/golang/build.go
@@ -69,8 +69,6 @@ func (b *BuildActionHandler) HandleAction(ctx context.Context) error {
 		return fmt.Errorf("failed to start go command: %w", err)
 	}
 
-	b.logger.Infof("building %s", b.args.PackageName)
-
 	if err := cmd.Wait(); err != nil {
 		return executil.FormatExitError(err)
 	}

--- a/internal/v2/actions/golang/run.go
+++ b/internal/v2/actions/golang/run.go
@@ -39,7 +39,7 @@ func NewRunActionHandler(ctx context.Context, ref manifest.JobHandlerRef, params
 	return engine.NewHandlerResult(h, diags)
 }
 
-func (b *RunActionHandler) HandleAction(ctx context.Context) error {
+func (b *RunActionHandler) HandleAction(ctx context.Context, emitter engine.SignalEmitter) error {
 	argv, err := b.args.commandArgs()
 	if err != nil {
 		return err

--- a/internal/v2/actions/os/process.go
+++ b/internal/v2/actions/os/process.go
@@ -36,7 +36,7 @@ func NewProcessActionHandler(ctx context.Context, ref manifest.JobHandlerRef, pa
 	return engine.NewHandlerResult(h, diags)
 }
 
-func (h *ProcessActionHandler) HandleAction(ctx context.Context) error {
+func (h *ProcessActionHandler) HandleAction(ctx context.Context, emitter engine.SignalEmitter) error {
 	cmd := exec.CommandContext(ctx, h.args.Path, h.args.Args...)
 	cmd.Env = executil.MergeEnv(h.args.Env, h.globals.Env)
 	cmd.Dir = h.globals.Project.WorkDir

--- a/internal/v2/actions/os/shell.go
+++ b/internal/v2/actions/os/shell.go
@@ -36,7 +36,7 @@ func NewShellActionHandler(ctx context.Context, ref manifest.JobHandlerRef, para
 	return engine.NewHandlerResult(h, diags)
 }
 
-func (s *ShellActionHandler) HandleAction(ctx context.Context) error {
+func (s *ShellActionHandler) HandleAction(ctx context.Context, emitter engine.SignalEmitter) error {
 	cmd := exec.CommandContext(ctx, s.args.Shell, s.args.ShellCommand, s.args.Command)
 	cmd.Env = executil.MergeEnv(s.args.Env, s.globals.Env)
 	cmd.Dir = s.globals.Project.WorkDir

--- a/internal/v2/actions/provider.go
+++ b/internal/v2/actions/provider.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"context"
 
+	"github.com/go-gilbert/gilbert/internal/v2/actions/debug"
 	"github.com/go-gilbert/gilbert/internal/v2/actions/golang"
 	"github.com/go-gilbert/gilbert/internal/v2/actions/os"
 	"github.com/go-gilbert/gilbert/internal/v2/engine"
@@ -14,8 +15,9 @@ var (
 	Provider engine.ActionHandlerProvider = ActionHandlerProvider{}
 
 	namespaces = map[string]map[string]engine.ActionHandlerConstructor{
-		"go": golang.Actions,
-		"os": os.Actions,
+		"go":    golang.Actions,
+		"os":    os.Actions,
+		"debug": debug.Actions,
 	}
 )
 

--- a/internal/v2/cmd/cmdutil/inputflag/binder.go
+++ b/internal/v2/cmd/cmdutil/inputflag/binder.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/pflag"
+
 	"github.com/go-gilbert/gilbert/internal/v2/log"
 	"github.com/go-gilbert/gilbert/internal/v2/manifest"
 	"github.com/go-gilbert/gilbert/internal/v2/scope"
 	"github.com/go-gilbert/gilbert/pkg/expr"
-	"github.com/spf13/pflag"
 )
 
 // inputFlagBinding is interface to implement binding from job file input into command-line flags.
@@ -83,7 +84,15 @@ func (b *InputFlagsBinder) BindInputsToFlagSet(ctx context.Context, fset *pflag.
 			requiredFlags = append(requiredFlags, flagName)
 		}
 
-		fset.Var(binding, flagName, flagDoc)
+		// Boolean flags need special treatment as they're not required to have a value.
+		// Replicate pflag.BoolVar behavior.
+		isBool := input.Schema.Type == manifest.ValueTypeBool
+		if isBool {
+			f := fset.VarPF(binding, flagName, "", flagDoc)
+			f.NoOptDefVal = "true"
+		} else {
+			fset.Var(binding, flagName, flagDoc)
+		}
 	}
 
 	return requiredFlags, nil

--- a/internal/v2/engine/handler.go
+++ b/internal/v2/engine/handler.go
@@ -30,7 +30,13 @@ type ActionParams struct {
 	Outputs []string
 }
 
+// ErrorSignal is a name of internal signal sent on job error.
+const ErrorSignal = "error"
+
 type SignalEmitter interface {
+	// EmitSignal calls jobs attached to a slot of a given job signal.
+	//
+	// Note: call of internal signals, such as [ErrorSignal] is forbidden.
 	EmitSignal(ctx context.Context, name string, data map[string]any) error
 }
 

--- a/internal/v2/engine/handler.go
+++ b/internal/v2/engine/handler.go
@@ -25,7 +25,13 @@ type ActionParams struct {
 	EvalParams expr.EvalParams
 
 	// Outputs is a set of output values that are expected to be returned to a job.
+	//
+	// Value acts as a hint for a job to avoid persisting unnecessary artifacts.
 	Outputs []string
+}
+
+type SignalEmitter interface {
+	EmitSignal(ctx context.Context, name string, data map[string]any) error
 }
 
 type HandlerResult struct {
@@ -78,5 +84,5 @@ type ActionHandlerProvider interface {
 }
 
 type ActionHandler interface {
-	HandleAction(ctx context.Context) error
+	HandleAction(ctx context.Context, emitter SignalEmitter) error
 }

--- a/internal/v2/engine/runner.go
+++ b/internal/v2/engine/runner.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 
@@ -233,8 +234,9 @@ func (r *Runner) handleJob(ctx context.Context, j manifest.Job, jobScope *scope.
 		return r.handleMixin(ctx, j, jobScope)
 	}
 
+	jobName := j.Handler.String()
 	hResult := r.actionHandlers.GetActionHandler(ctx, j.Handler, ActionParams{
-		Logger: r.logger.Named(j.Handler.String()),
+		Logger: r.logger.Named(jobName),
 		Shell:  r.shell,
 		Scope:  jobScope,
 		Args:   j.Args,
@@ -261,23 +263,35 @@ func (r *Runner) handleJob(ctx context.Context, j manifest.Job, jobScope *scope.
 	}
 
 	r.shell.Reporter.OnJobStart(JobStartEvent{
-		JobName:          j.Handler.String(),
+		JobName:          jobName,
 		MatrixParameters: jobScope.MatrixValues,
 	})
 
 	runCtx, cancelFn := j.WrapContext(ctx)
 	defer cancelFn()
 
-	emitter := r.newSignalEmitter(jobScope, j.Hooks)
-	return hResult.Handler.HandleAction(runCtx, emitter)
+	emitter := r.newSignalEmitter(jobName, jobScope, j.Hooks)
+	err := hResult.Handler.HandleAction(runCtx, emitter)
+	emitter.callErrorHook(ctx, err)
+	return err
 }
 
-func (r *Runner) newSignalEmitter(parentScope *scope.Scope, hooks manifest.SignalHooks) SignalEmitter {
+// signalEmitterPrivate is a wrapper interface around public's SignalEmiiter.
+//
+// Contains private functionality restricted to runner internal use.
+type signalEmitterPrivate interface {
+	SignalEmitter
+
+	callErrorHook(ctx context.Context, err error)
+}
+
+func (r *Runner) newSignalEmitter(sender string, parentScope *scope.Scope, hooks manifest.SignalHooks) signalEmitterPrivate {
 	if len(hooks) == 0 {
 		return noopSignalEmitter{}
 	}
 
 	return &signalEmitter{
+		sender:      sender,
 		runner:      r,
 		hooks:       hooks,
 		parentScope: parentScope,
@@ -285,9 +299,36 @@ func (r *Runner) newSignalEmitter(parentScope *scope.Scope, hooks manifest.Signa
 }
 
 type signalEmitter struct {
+	sender      string
 	runner      *Runner
 	parentScope *scope.Scope
 	hooks       manifest.SignalHooks
+}
+
+const errSignalTimeout = 5 * time.Second
+
+func (em *signalEmitter) callErrorHook(ctx context.Context, err error) {
+	if err == nil {
+		return
+	}
+
+	// early check to avoid allocating arg map if not needed.
+	_, ok := em.hooks["error"]
+	if !ok {
+		em.runner.logger.Debug("no error handler hooks, skip")
+		return
+	}
+
+	if ctx.Err() != nil {
+		// if canceled - replace with deadline to allow cleanup hooks to run
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(context.WithoutCancel(ctx), errSignalTimeout)
+		defer cancel()
+	}
+
+	em.runHooks(ctx, "error", map[string]any{
+		"error": err.Error(),
+	})
 }
 
 func (em *signalEmitter) EmitSignal(ctx context.Context, name string, data map[string]any) error {
@@ -295,26 +336,38 @@ func (em *signalEmitter) EmitSignal(ctx context.Context, name string, data map[s
 		return err
 	}
 
+	em.runHooks(ctx, name, data)
+	return nil
+}
+
+func (em *signalEmitter) runHooks(ctx context.Context, name string, data map[string]any) {
 	jobs, ok := em.hooks[name]
 	if !ok {
 		em.runner.logger.Debugf("no hooks for signal %q, skip", name)
-		return nil
+		return
 	}
 
 	s := em.parentScope.Fork()
 	s.EventData = data
 
-	em.runner.logger.Debugw("call signal", log.NewField("name", name), log.NewField("data", data))
+	em.runner.shell.Reporter.OnSignal(SignalEvent{
+		SignalName: name,
+		Sender:     em.sender,
+		Args:       data,
+	})
+
 	err := em.runner.runJobGroup(ctx, jobs, s)
 	if err != nil {
 		// signal handlers are allowed to fail
 		em.runner.logger.Warnf("signal %q returned an error: %s", name, err)
 	}
-
-	return nil
 }
 
 type noopSignalEmitter struct{}
+
+func (_ noopSignalEmitter) callErrorHook(ctx context.Context, err error) {
+	// NOOP
+}
 
 func (_ noopSignalEmitter) EmitSignal(ctx context.Context, name string, data map[string]any) error {
 	return validateSignalIsAllowed(name)

--- a/internal/v2/engine/runner.go
+++ b/internal/v2/engine/runner.go
@@ -268,27 +268,47 @@ func (r *Runner) handleJob(ctx context.Context, j manifest.Job, jobScope *scope.
 	runCtx, cancelFn := j.WrapContext(ctx)
 	defer cancelFn()
 
-	emitter := r.newSignalEmitter(j.Hooks)
+	emitter := r.newSignalEmitter(jobScope, j.Hooks)
 	return hResult.Handler.HandleAction(runCtx, emitter)
 }
 
-func (r *Runner) newSignalEmitter(hooks manifest.SignalHooks) SignalEmitter {
+func (r *Runner) newSignalEmitter(parentScope *scope.Scope, hooks manifest.SignalHooks) SignalEmitter {
 	if len(hooks) == 0 {
 		return noopSignalEmitter{}
 	}
 
 	return &signalEmitter{
-		hooks: hooks,
+		runner:      r,
+		hooks:       hooks,
+		parentScope: parentScope,
 	}
 }
 
 type signalEmitter struct {
-	hooks manifest.SignalHooks
+	runner      *Runner
+	parentScope *scope.Scope
+	hooks       manifest.SignalHooks
 }
 
-func (emitter *signalEmitter) EmitSignal(ctx context.Context, name string, data map[string]any) error {
+func (em *signalEmitter) EmitSignal(ctx context.Context, name string, data map[string]any) error {
 	if err := validateSignalIsAllowed(name); err != nil {
 		return err
+	}
+
+	jobs, ok := em.hooks[name]
+	if !ok {
+		em.runner.logger.Debugf("no hooks for signal %q, skip", name)
+		return nil
+	}
+
+	s := em.parentScope.Fork()
+	s.EventData = data
+
+	em.runner.logger.Debugw("call signal", log.NewField("name", name), log.NewField("data", data))
+	err := em.runner.runJobGroup(ctx, jobs, s)
+	if err != nil {
+		// signal handlers are allowed to fail
+		em.runner.logger.Warnf("signal %q returned an error: %s", name, err)
 	}
 
 	return nil

--- a/internal/v2/engine/runner.go
+++ b/internal/v2/engine/runner.go
@@ -268,5 +268,42 @@ func (r *Runner) handleJob(ctx context.Context, j manifest.Job, jobScope *scope.
 	runCtx, cancelFn := j.WrapContext(ctx)
 	defer cancelFn()
 
-	return hResult.Handler.HandleAction(runCtx)
+	emitter := r.newSignalEmitter(j.Hooks)
+	return hResult.Handler.HandleAction(runCtx, emitter)
+}
+
+func (r *Runner) newSignalEmitter(hooks manifest.SignalHooks) SignalEmitter {
+	if len(hooks) == 0 {
+		return noopSignalEmitter{}
+	}
+
+	return &signalEmitter{
+		hooks: hooks,
+	}
+}
+
+type signalEmitter struct {
+	hooks manifest.SignalHooks
+}
+
+func (emitter *signalEmitter) EmitSignal(ctx context.Context, name string, data map[string]any) error {
+	if err := validateSignalIsAllowed(name); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type noopSignalEmitter struct{}
+
+func (_ noopSignalEmitter) EmitSignal(ctx context.Context, name string, data map[string]any) error {
+	return validateSignalIsAllowed(name)
+}
+
+func validateSignalIsAllowed(name string) error {
+	if name == "error" {
+		return fmt.Errorf("sending of internal signal is not allowed: %q", name)
+	}
+
+	return nil
 }

--- a/internal/v2/engine/runner.go
+++ b/internal/v2/engine/runner.go
@@ -352,7 +352,7 @@ func (em *signalEmitter) runHooks(ctx context.Context, name string, data map[str
 
 	em.runner.shell.Reporter.OnSignal(SignalEvent{
 		SignalName: name,
-		Sender:     em.sender,
+		JobName:    em.sender,
 		Args:       data,
 	})
 

--- a/internal/v2/engine/shell.go
+++ b/internal/v2/engine/shell.go
@@ -14,7 +14,7 @@ type JobStartEvent struct {
 
 type SignalEvent struct {
 	SignalName string
-	Sender     string
+	JobName    string
 	Args       map[string]any
 }
 

--- a/internal/v2/engine/shell.go
+++ b/internal/v2/engine/shell.go
@@ -12,6 +12,12 @@ type JobStartEvent struct {
 	MatrixParameters map[string]any
 }
 
+type SignalEvent struct {
+	SignalName string
+	Sender     string
+	Args       map[string]any
+}
+
 // Reporter reports application updates to user interface.
 type Reporter interface {
 	// OnTaskStart reports task execution start event.
@@ -19,6 +25,9 @@ type Reporter interface {
 
 	// OnJobStart reports task step execution start event.
 	OnJobStart(event JobStartEvent)
+
+	// OnSignal reports when action handler emits a signal.
+	OnSignal(event SignalEvent)
 
 	// PrintDiagnostics renders diagnostics.
 	PrintDiagnostics(diags parsetypes.Diagnostics)

--- a/internal/v2/manifest/argschema/structmapper.go
+++ b/internal/v2/manifest/argschema/structmapper.go
@@ -142,7 +142,7 @@ func Dict[T any](valType ValueConverter[T]) *AnyValueVisitor[map[string]T] {
 
 				tval, err := valType.ConvertValue(vp, rv)
 				if err != nil {
-					return nil, fmt.Errorf("invalid value for key %q: %w", k, tval)
+					return nil, fmt.Errorf("invalid value for key %q: %v", k, tval)
 				}
 
 				out[k] = tval

--- a/internal/v2/manifest/jobfile.go
+++ b/internal/v2/manifest/jobfile.go
@@ -87,6 +87,8 @@ type JobArgs struct {
 	Values   map[string]*LazyValue
 }
 
+type SignalHooks = map[string][]Job
+
 type Job struct {
 	// Location contains information about where job is defined.
 	Location ReferenceLocation
@@ -124,7 +126,7 @@ type Job struct {
 	Args JobArgs
 
 	// Hooks is key-value pair of event name and actions to be run on event.
-	Hooks map[string][]Job
+	Hooks SignalHooks
 }
 
 var nopCancelFn = func() {}

--- a/internal/v2/manifest/loader/yamlloader/inputs.go
+++ b/internal/v2/manifest/loader/yamlloader/inputs.go
@@ -17,7 +17,7 @@ import (
 var listTypeSchema = Struct(
 	Field("type",
 		Transform(String(), func(_ context.Context, _ ast.Node, v string) (manifest.ValueType, error) {
-			return manifest.ParseValueType(v)
+			return parseValueType(v)
 		}),
 		func(_ context.Context, dst *manifest.TypeSchema, val manifest.ValueType) error {
 			if val.IsComplex() {
@@ -54,7 +54,7 @@ var inputsSchema = Map(Pointer(inputDefinitionSchema)).
 var inputDefinitionSchema = Struct(
 	Field("type",
 		Transform(String(), func(_ context.Context, _ ast.Node, s string) (manifest.ValueType, error) {
-			return manifest.ParseValueType(s)
+			return parseValueType(s)
 		}),
 		func(_ context.Context, dst *manifest.InputDefinition, val manifest.ValueType) error {
 			dst.Schema.Type = val
@@ -325,6 +325,23 @@ func (v defaultValVisitor) VisitItem(ctx context.Context, opts *TraverseOpts, no
 	}
 
 	return v.readOtherNode(ctx, opts, &loc, node)
+}
+
+func parseValueType(value string) (manifest.ValueType, error) {
+	vt, err := manifest.ParseValueType(value)
+	// Add hints for common typos
+	if err != nil {
+		switch value {
+		case "array":
+			err = parsetypes.NewAnnotatedError(err, `did you mean: list ?`)
+		case "boolean":
+			err = parsetypes.NewAnnotatedError(err, `did you mean: bool ?`)
+		default:
+			err = parsetypes.NewAnnotatedError(err, "should be one of: string, int, bool, date, duration, float, list")
+		}
+	}
+
+	return vt, err
 }
 
 func intoAny[T any](_ context.Context, _ ast.Node, s T) (any, error) {

--- a/internal/v2/scope/expr.go
+++ b/internal/v2/scope/expr.go
@@ -67,6 +67,7 @@ type exprEnvironment struct {
 	Project ProjectInfo       `expr:"project"`
 	Env     map[string]string `expr:"env"`
 	Matrix  map[string]any    `expr:"matrix"`
+	Event   map[string]any    `expr:"event"`
 }
 
 func newExprEnvironment(s *Scope) *exprEnvironment {
@@ -80,5 +81,6 @@ func newExprEnvironment(s *Scope) *exprEnvironment {
 		Matrix:  s.MatrixValues,
 		Project: s.Globals.Project,
 		Env:     s.Globals.Env,
+		Event:   s.EventData,
 	}
 }

--- a/internal/v2/scope/scope.go
+++ b/internal/v2/scope/scope.go
@@ -42,6 +42,12 @@ type Scope struct {
 
 	// MatrixValues is values populated by job matrix execution strategy.
 	MatrixValues map[string]any
+
+	// EventData contains signal event data.
+	//
+	// Populated to jobs called by a signal.
+	// Contents of event data depends on event and sender.
+	EventData map[string]any
 }
 
 // ValueByName is a stub for expr.EvalContext compatibility.
@@ -65,6 +71,7 @@ func (s *Scope) Fork() *Scope {
 		Consts:       s.Consts,
 		Inputs:       map[string]any{}, // no need to copy as we've a reference to a parent.
 		MatrixValues: s.MatrixValues,
+		EventData:    s.EventData,
 	}
 
 	return newScope

--- a/internal/v2/ui/headless.go
+++ b/internal/v2/ui/headless.go
@@ -50,6 +50,16 @@ func (l *LogReporter) OnTaskStart(taskName string) {
 	l.log.Infof("starting task %q", taskName)
 }
 
+func (l *LogReporter) OnSignal(event engine.SignalEvent) {
+	fields := []log.Field{
+		log.NewField("job", event.JobName),
+		log.NewField("signal", event.SignalName),
+		log.NewField("args", event.Args),
+	}
+
+	l.log.Infow("job sent signal", fields...)
+}
+
 func (l *LogReporter) PrintDiagnostics(diags parsetypes.Diagnostics) {
 	l.diagRenderer.RenderDiagnostics(diags)
 	l.diagRenderer.Reset()

--- a/internal/v2/ui/terminal.go
+++ b/internal/v2/ui/terminal.go
@@ -72,6 +72,14 @@ func (r *TerminalReporter) OnJobStart(e engine.JobStartEvent) {
 	r.stdout.Write(b.Bytes())
 }
 
+func (r *TerminalReporter) OnSignal(event engine.SignalEvent) {
+	if event.SignalName == engine.ErrorSignal {
+		r.Printf(r.palette.ErrMarker, "!! job %q sent signal %q\n", event.JobName, event.SignalName)
+	} else {
+		r.Printf(r.palette.NoteMarker, "!! job %q sent signal %q\n", event.JobName, event.SignalName)
+	}
+}
+
 func (r *TerminalReporter) PrintDiagnostics(diags parsetypes.Diagnostics) {
 	r.diagRenderer.RenderDiagnostics(diags)
 	r.diagRenderer.Reset()

--- a/pkg/parsetypes/cast.go
+++ b/pkg/parsetypes/cast.go
@@ -1,6 +1,7 @@
 package parsetypes
 
 import (
+	"errors"
 	"fmt"
 	"iter"
 	"reflect"
@@ -235,7 +236,7 @@ func AnyToDuration(v any) (time.Duration, error) {
 	}
 
 	if u < 0 {
-		return 0, fmt.Errorf("number of miliseconds should be >= 0", u)
+		return 0, errors.New("number of miliseconds should be >= 0", u)
 	}
 
 	return u * time.Millisecond, nil

--- a/pkg/parsetypes/cast.go
+++ b/pkg/parsetypes/cast.go
@@ -1,7 +1,6 @@
 package parsetypes
 
 import (
-	"errors"
 	"fmt"
 	"iter"
 	"reflect"
@@ -236,7 +235,7 @@ func AnyToDuration(v any) (time.Duration, error) {
 	}
 
 	if u < 0 {
-		return 0, errors.New("number of miliseconds should be >= 0", u)
+		return 0, fmt.Errorf("number of miliseconds should be >= 0, got: %v", u)
 	}
 
 	return u * time.Millisecond, nil


### PR DESCRIPTION
Support signals and slots for actions.

Example:

```yaml
tasks:
  # Task to debug task runner
  test:
    inputs:
      # Test message content
      message:
        type: string

      # Signal name
      signal:
        type: string
        default: mysignal

    steps:
      - action: debug/signal
        with:
          signal: ${{inputs.signal}}
        on:
          mysignal:
            - action: debug/echo
              with:
                message: "message: ${{inputs.message}}, data: ${{toJSON(event)}}"
          error:
            - action: debug/echo
              with:
                message: Error happened
```