### PR TITLE
feat: Support subtasks and mixins

### DIFF
--- a/docs/testdata/gilbert.yml
+++ b/docs/testdata/gilbert.yml
@@ -34,7 +34,35 @@ inputs:
   #   items:
   #     type: int
 
+mixins:
+  hello:
+    inputs:
+      name:
+        type: string
+      greeting:
+        type: string
+        default: Hello
+    steps:
+      - action: debug/echo
+        with:
+          message: "${{inputs.greeting}}, ${{inputs.name}}!"
+      - action: debug/echo
+        delay: 300ms
+        with:
+          message: "Goodbye, ${{inputs.name}}"
+
 tasks:
+  test:mixin:
+    steps:
+      - mixin: hello
+        workDir: ..
+        with:
+          name: Bob
+          greeting: Howdy
+      - action: debug/echo
+        with:
+          message: "This is the end, ${{inputs.name}}"
+
   # Task to debug task runner
   test:
     inputs:

--- a/docs/testdata/gilbert.yml
+++ b/docs/testdata/gilbert.yml
@@ -59,7 +59,7 @@ tasks:
     steps:
       - task: test:subtask:child
         with:
-          message: "subtasks with message: ${{inputs.message}}"
+          msg: "subtasks with message: ${{inputs.message}}"
 
   test:subtask:child:
     inputs:

--- a/docs/testdata/gilbert.yml
+++ b/docs/testdata/gilbert.yml
@@ -55,7 +55,7 @@ tasks:
   test:mixin:
     steps:
       - mixin: hello
-        workDir: ..
+        working-directory: ..
         with:
           name: Bob
           greeting: Howdy

--- a/docs/testdata/gilbert.yml
+++ b/docs/testdata/gilbert.yml
@@ -52,6 +52,15 @@ mixins:
           message: "Goodbye, ${{inputs.name}}"
 
 tasks:
+  test:subtask:
+    inputs:
+      message:
+        type: string
+    steps:
+      - action: debug/echo
+        with:
+          message: "subtasks with message: ${{inputs.message}}"
+
   test:mixin:
     steps:
       - mixin: hello

--- a/docs/testdata/gilbert.yml
+++ b/docs/testdata/gilbert.yml
@@ -57,9 +57,18 @@ tasks:
       message:
         type: string
     steps:
-      - action: debug/echo
+      - task: test:subtask:child
         with:
           message: "subtasks with message: ${{inputs.message}}"
+
+  test:subtask:child:
+    inputs:
+      msg:
+        type: string
+    steps:
+      - action: debug/echo
+        with:
+          message: "${{inputs.msg}}"
 
   test:mixin:
     steps:

--- a/internal/v2/cmd/cmdutil/inputflag/array.go
+++ b/internal/v2/cmd/cmdutil/inputflag/array.go
@@ -7,10 +7,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/spf13/pflag"
+
 	"github.com/go-gilbert/gilbert/internal/v2/log"
 	"github.com/go-gilbert/gilbert/internal/v2/manifest"
 	"github.com/go-gilbert/gilbert/pkg/parsetypes"
-	"github.com/spf13/pflag"
 )
 
 var (
@@ -28,6 +29,10 @@ func newListInputFlagBinding(logger *log.Logger, def *manifest.InputDefinition, 
 	return &listInputFlagBinding{
 		inputBindingBase: newInputBindingBase(logger, def, flagCtx),
 	}
+}
+
+func (b *listInputFlagBinding) IsBoolFlag() bool {
+	return false
 }
 
 func (b *listInputFlagBinding) checkItemDecoder() error {

--- a/internal/v2/cmd/cmdutil/inputflag/binder.go
+++ b/internal/v2/cmd/cmdutil/inputflag/binder.go
@@ -18,6 +18,9 @@ import (
 type inputFlagBinding interface {
 	pflag.Value
 
+	// IsBoolFlag method implements pflag's boolean flag contract.
+	IsBoolFlag() bool
+
 	// getDoc returns flag documentation.
 	getDoc(isGlobal bool) string
 

--- a/internal/v2/cmd/cmdutil/inputflag/scalar.go
+++ b/internal/v2/cmd/cmdutil/inputflag/scalar.go
@@ -24,6 +24,10 @@ func newScalarInputFlagBinding(logger *log.Logger, def *manifest.InputDefinition
 	}
 }
 
+func (i *scalarInputFlagBinding) IsBoolFlag() bool {
+	return i.inputDef.Schema.Type == manifest.ValueTypeBool
+}
+
 func (i *scalarInputFlagBinding) checkType() error {
 	typeDef := i.inputDef.Schema
 	if !typeDef.Type.IsComplex() {
@@ -121,6 +125,7 @@ func (i *scalarInputFlagBinding) setValueFromInput(val string, isDefault bool) e
 }
 
 func (i *scalarInputFlagBinding) String() string {
+	typ := i.inputDef.Schema.Type
 	val, ok := i.flagCtx.dstScope.Inputs[i.inputDef.Name]
 	if !ok || val == nil {
 		return ""
@@ -128,7 +133,7 @@ func (i *scalarInputFlagBinding) String() string {
 
 	// TODO: make this in a proper way
 	var strVal string
-	switch i.inputDef.Schema.Type {
+	switch typ {
 	case manifest.ValueTypeDate:
 		if dt, ok := val.(time.Time); ok {
 			strVal = dt.Format(i.inputDef.Schema.DateFormatOrDefault())

--- a/internal/v2/engine/runner.go
+++ b/internal/v2/engine/runner.go
@@ -205,11 +205,24 @@ func (r *Runner) runJobMatrix(ctx context.Context, j manifest.Job, taskScope *sc
 	return g.Wait()
 }
 
-func (r *Runner) handleMixin(ctx context.Context, j manifest.Job, jobScope *scope.Scope) error {
+func (r *Runner) runSubtask(ctx context.Context, j manifest.Job, jobScope *scope.Scope, kind manifest.JobKind) error {
 	name := j.Handler.Name
-	mixin, ok := r.jobFile.Mixins[name]
+
+	var (
+		group *manifest.JobGroup
+		ok    bool
+	)
+	switch kind {
+	case manifest.JobKindMixin:
+		group, ok = r.jobFile.Mixins[name]
+	case manifest.JobKindTask:
+		group, ok = r.jobFile.Tasks[name]
+	default:
+		return fmt.Errorf("internal error: runSubtask: bad subtask kind: %v", kind)
+	}
+
 	if !ok {
-		return fmt.Errorf("mixin %q doesn't exist", name)
+		return fmt.Errorf("%s %q doesn't exist", kind, name)
 	}
 
 	// Scratch scope with different workdir to evaluate expressions.
@@ -220,7 +233,7 @@ func (r *Runner) handleMixin(ctx context.Context, j manifest.Job, jobScope *scop
 
 	inputs, diags := manifest.MapArgsToInputs(ctx, manifest.MapArgsParams{
 		Values:  j.Args,
-		Spec:    mixin.Inputs,
+		Spec:    group.Inputs,
 		EnvVars: jobScope.Globals.Env,
 		EvalParams: expr.EvalParams{
 			CommandProcessor: r.cmdProcBuilder(exprScope),
@@ -229,7 +242,7 @@ func (r *Runner) handleMixin(ctx context.Context, j manifest.Job, jobScope *scop
 	})
 	r.shell.Reporter.PrintDiagnostics(diags)
 	if diags.HasError() {
-		return fmt.Errorf("invalid input parameters for mixin %q", name)
+		return fmt.Errorf("invalid input parameters for %s %q", kind, name)
 	}
 
 	// Build a new scope which doesn't reference parent variables.
@@ -237,17 +250,17 @@ func (r *Runner) handleMixin(ctx context.Context, j manifest.Job, jobScope *scop
 	s := jobScope.Root.Fork().WithWorkDir(j.WorkDir)
 	s.Inputs = inputs
 
-	err := r.runJobGroup(ctx, mixin.Jobs, s)
+	err := r.runJobGroup(ctx, group.Jobs, s)
 	if err != nil {
-		return fmt.Errorf("mixin %q returned error: %w", name, err)
+		return fmt.Errorf("%s %q returned error: %w", kind, name, err)
 	}
 
 	return nil
 }
 
 func (r *Runner) handleJob(ctx context.Context, j manifest.Job, jobScope *scope.Scope) error {
-	if j.Kind == manifest.JobKindMixin {
-		return r.handleMixin(ctx, j, jobScope)
+	if j.Kind != manifest.JobKindAction {
+		return r.runSubtask(ctx, j, jobScope, j.Kind)
 	}
 
 	jobName := j.Handler.String()

--- a/internal/v2/engine/runner.go
+++ b/internal/v2/engine/runner.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -207,12 +208,27 @@ func (r *Runner) runJobMatrix(ctx context.Context, j manifest.Job, taskScope *sc
 
 func (r *Runner) handleMixin(ctx context.Context, j manifest.Job, jobScope *scope.Scope) error {
 	name := j.Handler.Name
-	_, ok := r.jobFile.Mixins[name]
+	mixin, ok := r.jobFile.Mixins[name]
 	if !ok {
 		return fmt.Errorf("mixin %q doesn't exist", name)
 	}
 
-	// TODO: resolve mixin scope from parent
+	// Build a new scope which doesn't reference parent variables.
+	// Change work dir if necessary.
+	s := jobScope.Root.Fork()
+	if j.WorkDir != "" {
+		newWd := j.WorkDir
+		if !filepath.IsAbs(newWd) {
+			newWd = filepath.Join(jobScope.Globals.Project.WorkDir, newWd)
+		}
+
+		s.Globals.Project.WorkDir = filepath.Clean(newWd)
+	}
+
+	_ = s
+	_ = mixin
+	// TODO: map job args to scope
+
 	loc := j.Handler.Location
 	r.shell.Reporter.PrintDiagnostics(
 		parsetypes.Diagnostics{

--- a/internal/v2/engine/runner.go
+++ b/internal/v2/engine/runner.go
@@ -61,7 +61,7 @@ func (r *Runner) RunTaskWithScope(ctx context.Context, name string, s *scope.Sco
 		return fmt.Errorf("task %q not found", name)
 	}
 
-	r.shell.Reporter.OnTaskStart(name)
+	r.shell.Reporter.OnTaskStart(TaskStartEvent{TaskName: name})
 	return r.runJobGroup(ctx, t.Jobs, s)
 }
 
@@ -205,6 +205,7 @@ func (r *Runner) runJobMatrix(ctx context.Context, j manifest.Job, taskScope *sc
 	return g.Wait()
 }
 
+// runSubtask starts mixin or task as a sub-task with its own separate scope.
 func (r *Runner) runSubtask(ctx context.Context, j manifest.Job, jobScope *scope.Scope, kind manifest.JobKind) error {
 	name := j.Handler.Name
 
@@ -218,7 +219,7 @@ func (r *Runner) runSubtask(ctx context.Context, j manifest.Job, jobScope *scope
 	case manifest.JobKindTask:
 		group, ok = r.jobFile.Tasks[name]
 	default:
-		return fmt.Errorf("internal error: runSubtask: bad subtask kind: %v", kind)
+		panic("internal error: runSubtask: bad subtask kind: " + kind.String())
 	}
 
 	if !ok {
@@ -243,6 +244,13 @@ func (r *Runner) runSubtask(ctx context.Context, j manifest.Job, jobScope *scope
 	r.shell.Reporter.PrintDiagnostics(diags)
 	if diags.HasError() {
 		return fmt.Errorf("invalid input parameters for %s %q", kind, name)
+	}
+
+	if kind == manifest.JobKindTask {
+		r.shell.Reporter.OnTaskStart(TaskStartEvent{
+			TaskName:  name,
+			IsSubTask: true,
+		})
 	}
 
 	// Build a new scope which doesn't reference parent variables.

--- a/internal/v2/engine/runner.go
+++ b/internal/v2/engine/runner.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path/filepath"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -213,48 +212,37 @@ func (r *Runner) handleMixin(ctx context.Context, j manifest.Job, jobScope *scop
 		return fmt.Errorf("mixin %q doesn't exist", name)
 	}
 
-	// Scratch scope to evaluate expressions, but based on different workdir.
+	// Scratch scope with different workdir to evaluate expressions.
+	exprScope := jobScope
+	if j.WorkDir != "" {
+		exprScope = jobScope.Fork().WithWorkDir(j.WorkDir)
+	}
 
-	manifest.MapArgsToInputs(ctx, manifest.MapArgsParams{
+	inputs, diags := manifest.MapArgsToInputs(ctx, manifest.MapArgsParams{
 		Values:  j.Args,
 		Spec:    mixin.Inputs,
 		EnvVars: jobScope.Globals.Env,
 		EvalParams: expr.EvalParams{
-			CommandProcessor: r.cmdProcBuilder(jobScope),
-			Env:              jobScope,
+			CommandProcessor: r.cmdProcBuilder(exprScope),
+			Env:              exprScope,
 		},
 	})
+	r.shell.Reporter.PrintDiagnostics(diags)
+	if diags.HasError() {
+		return fmt.Errorf("invalid input parameters for mixin %q", name)
+	}
 
 	// Build a new scope which doesn't reference parent variables.
 	// Change work dir if necessary.
-	s := jobScope.Root.Fork()
-	if j.WorkDir != "" {
-		newWd := j.WorkDir
-		if !filepath.IsAbs(newWd) {
-			newWd = filepath.Join(jobScope.Globals.Project.WorkDir, newWd)
-		}
+	s := jobScope.Root.Fork().WithWorkDir(j.WorkDir)
+	s.Inputs = inputs
 
-		s.Globals.Project.WorkDir = filepath.Clean(newWd)
+	err := r.runJobGroup(ctx, mixin.Jobs, s)
+	if err != nil {
+		return fmt.Errorf("mixin %q returned error: %w", name, err)
 	}
 
-	_ = s
-	_ = mixin
-	// TODO: map job args to scope
-
-	loc := j.Handler.Location
-	r.shell.Reporter.PrintDiagnostics(
-		parsetypes.Diagnostics{
-			&parsetypes.Diagnostic{
-				FileName: loc.FileName,
-				Severity: parsetypes.DiagnosticSeverityError,
-				Range:    loc.Range,
-				Offset:   loc.Offset,
-				Err:      fmt.Errorf("only action jobs are supported currently"),
-			},
-		},
-	)
-
-	return errors.New("only action jobs are supported currently")
+	return nil
 }
 
 func (r *Runner) handleJob(ctx context.Context, j manifest.Job, jobScope *scope.Scope) error {

--- a/internal/v2/engine/runner.go
+++ b/internal/v2/engine/runner.go
@@ -213,6 +213,18 @@ func (r *Runner) handleMixin(ctx context.Context, j manifest.Job, jobScope *scop
 		return fmt.Errorf("mixin %q doesn't exist", name)
 	}
 
+	// Scratch scope to evaluate expressions, but based on different workdir.
+
+	manifest.MapArgsToInputs(ctx, manifest.MapArgsParams{
+		Values:  j.Args,
+		Spec:    mixin.Inputs,
+		EnvVars: jobScope.Globals.Env,
+		EvalParams: expr.EvalParams{
+			CommandProcessor: r.cmdProcBuilder(jobScope),
+			Env:              jobScope,
+		},
+	})
+
 	// Build a new scope which doesn't reference parent variables.
 	// Change work dir if necessary.
 	s := jobScope.Root.Fork()

--- a/internal/v2/engine/shell.go
+++ b/internal/v2/engine/shell.go
@@ -18,6 +18,11 @@ type SignalEvent struct {
 	Args       map[string]any
 }
 
+type TaskStartEvent struct {
+	TaskName  string
+	IsSubTask bool
+}
+
 // Reporter reports application updates to user interface.
 type Reporter interface {
 	// OnTaskStart reports task execution start event.

--- a/internal/v2/engine/shell.go
+++ b/internal/v2/engine/shell.go
@@ -26,7 +26,7 @@ type TaskStartEvent struct {
 // Reporter reports application updates to user interface.
 type Reporter interface {
 	// OnTaskStart reports task execution start event.
-	OnTaskStart(taskName string)
+	OnTaskStart(event TaskStartEvent)
 
 	// OnJobStart reports task step execution start event.
 	OnJobStart(event JobStartEvent)

--- a/internal/v2/manifest/binder.go
+++ b/internal/v2/manifest/binder.go
@@ -63,7 +63,7 @@ func MapArgsToInputs(ctx context.Context, params MapArgsParams) (map[string]any,
 
 		// Fallback - read defaults
 		if spec.IsRequired() {
-			diags.Append(parameterRequiredDiagnostic(k, params.Values.Location))
+			diags = diags.Append(parameterRequiredDiagnostic(k, params.Values.Location))
 			continue
 		}
 
@@ -119,7 +119,7 @@ func MapArgsToInputs(ctx context.Context, params MapArgsParams) (map[string]any,
 			continue
 		}
 
-		diags.Append(parameterRequiredDiagnostic(k, params.Values.Location))
+		diags = diags.Append(parameterRequiredDiagnostic(k, params.Values.Location))
 		continue
 	}
 
@@ -137,7 +137,7 @@ func MapArgsToInputs(ctx context.Context, params MapArgsParams) (map[string]any,
 			Note:     "remove unnecessary parameter",
 			Err:      fmt.Errorf("unknown parameter %q", k),
 		}
-		diags.Append(diag)
+		diags = diags.Append(diag)
 	}
 
 	return dst, diags

--- a/internal/v2/manifest/binder.go
+++ b/internal/v2/manifest/binder.go
@@ -1,0 +1,251 @@
+package manifest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/go-gilbert/gilbert/pkg/expr"
+	"github.com/go-gilbert/gilbert/pkg/parsetypes"
+)
+
+type MapArgsParams struct {
+	// Values is source raw values.
+	Values JobArgs
+
+	// Spec is job inputs schema for type checking.
+	Spec Inputs
+
+	// EvalParams is evaluation params to expand expressions.
+	EvalParams expr.EvalParams
+
+	// EnvVars is environment variables map.
+	// Used to resolve default input default value when it contains env var binding.
+	EnvVars map[string]string
+}
+
+// MapArgsToInputs validates job arguments against inputs schema and returns expanded values.
+//
+// Main purpose of the function is to construct scope values for task execution.
+func MapArgsToInputs(ctx context.Context, params MapArgsParams) (map[string]any, parsetypes.Diagnostics) {
+	dst := make(map[string]any, len(params.Spec))
+	diags := parsetypes.Diagnostics{}
+
+	visited := map[string]struct{}{}
+	for k, spec := range params.Spec {
+		raw, ok := params.Values.Values[k]
+		if ok {
+			visited[k] = struct{}{}
+			v, diag := mapLazyValue(
+				ctx, raw,
+				valueMapOpts{
+					ep:       params.EvalParams,
+					spec:     spec.Schema,
+					allowNil: true, // will fallback to	defaults if empty
+				},
+			)
+
+			if len(diag) > 0 {
+				diags = append(diags, diag...)
+				if diag.HasError() {
+					continue
+				}
+			}
+
+			if v != nil {
+				dst[k] = v
+				continue
+			}
+		}
+
+		// Fallback - read defaults
+		if spec.IsRequired() {
+			diags.Append(parameterRequiredDiagnostic(k, params.Values.Location))
+			continue
+		}
+
+		// Env var takes precedence over explicit defaults
+		// Other types of bindings don't matter as they're supported in CLI context.
+		if spec.Binding != nil && spec.Binding.EnvVarName != "" && len(params.EnvVars) > 0 {
+			k := spec.Binding.EnvVarName
+			v, ok := params.EnvVars[k]
+			if ok && v != "" {
+				out, diag := mapEnvVar(spec, v)
+				if len(diag) > 0 {
+					diags = append(diags, diag...)
+				}
+
+				if !diags.HasError() {
+					dst[k] = out
+				}
+				continue
+			}
+		}
+
+		// Unpack explicit default value
+		if spec.DefaultValue != nil {
+			// TODO: build default value
+			out, diag := mapLazyValue(
+				ctx, &spec.DefaultValue.Value,
+				valueMapOpts{
+					ep:   params.EvalParams,
+					spec: spec.Schema,
+					note: "unable to expand default value",
+				},
+			)
+
+			if len(diag) > 0 {
+				diags = append(diags, diag...)
+				if diag.HasError() {
+					continue
+				}
+			}
+
+			dst[k] = out
+			continue
+		}
+
+		// Fallback for optionals
+		if spec.Schema.Type == ValueTypeBool {
+			dst[k] = false
+			continue
+		}
+
+		if spec.Optional {
+			dst[k] = NewZeroValue(spec.Schema.Type)
+			continue
+		}
+
+		diags.Append(parameterRequiredDiagnostic(k, params.Values.Location))
+		continue
+	}
+
+	// Throw warnings about unknown passed fields
+	for k, e := range params.Values.Values {
+		if _, isConsumed := visited[k]; isConsumed {
+			continue
+		}
+
+		diag := &parsetypes.Diagnostic{
+			FileName: e.Location.FileName,
+			Severity: parsetypes.DiagnosticSeverityWarning,
+			Range:    e.Location.Range,
+			Offset:   e.Location.Offset,
+			Note:     "remove unnecessary parameter",
+			Err:      fmt.Errorf("unknown parameter %q", k),
+		}
+		diags.Append(diag)
+	}
+
+	return dst, diags
+}
+
+func mapEnvVar(def *InputDefinition, val string) (any, parsetypes.Diagnostics) {
+	spec := def.Schema
+	loc := def.Binding.Location.EnvVarName
+	if loc == nil {
+		loc = &def.Location
+	}
+
+	if spec.Type.IsList() {
+		if spec.Items.Items.Type.IsComplex() {
+			err := fmt.Errorf("binding environment variables to []%s is not supported", spec.Items.Items.Type)
+			note := fmt.Sprintf("references environment variable %q", def.Binding.EnvVarName)
+			return nil, newDiagnostic(loc, err, note)
+		}
+
+		parts := strings.Split(val, def.Binding.DelimiterOrDefault())
+		out := make([]any, 0, len(parts))
+		for _, part := range parts {
+			v, err := spec.ParseValue(part)
+			if err != nil {
+				note := fmt.Sprintf("references environment variable %q", def.Binding.EnvVarName)
+				return nil, newDiagnostic(loc, err, note)
+			}
+
+			out = append(out, v)
+		}
+
+		return out, nil
+	}
+
+	if spec.Type.IsComplex() {
+		err := fmt.Errorf("binding environment variables to %s is not supported", spec.Type)
+		note := fmt.Sprintf("references environment variable %q", def.Binding.EnvVarName)
+		return nil, newDiagnostic(loc, err, note)
+	}
+
+	out, err := spec.ParseValue(val)
+	if err != nil {
+		note := fmt.Sprintf("references environment variable %q", def.Binding.EnvVarName)
+		return nil, newDiagnostic(loc, err, note)
+	}
+
+	return out, nil
+}
+
+type valueMapOpts struct {
+	ep       expr.EvalParams
+	spec     TypeSchema
+	note     string
+	allowNil bool
+}
+
+func mapLazyValue(ctx context.Context, val *LazyValue, opts valueMapOpts) (any, parsetypes.Diagnostics) {
+	raw, err := val.Expand(ctx, opts.ep)
+	if err != nil {
+		if diags, ok := parsetypes.IsDiagnosticsError(err); ok {
+			return nil, diags
+		}
+
+		return nil, newDiagnostic(val.Location, err, opts.note)
+	}
+
+	if t, ok := raw.(string); ok {
+		out, err := opts.spec.ParseValue(t)
+		if err != nil {
+			return nil, newDiagnostic(val.Location, err, opts.note)
+		}
+
+		return out, nil
+	}
+
+	if !opts.allowNil {
+		if raw == nil {
+			return nil, newDiagnostic(val.Location, errors.New("value cannot be nil"), opts.note)
+		}
+
+		// TODO: handle iface with nil value
+	}
+
+	switch opts.spec.Type {
+	// TODO: typecheck.
+	// NOTE: some scalar values can be casted between.
+	}
+
+	return nil, nil
+}
+
+func newDiagnostic(loc *ReferenceLocation, err error, note string) parsetypes.Diagnostics {
+	diag := &parsetypes.Diagnostic{
+		FileName: loc.FileName,
+		Severity: parsetypes.DiagnosticSeverityError,
+		Range:    loc.Range,
+		Offset:   loc.Offset,
+		Err:      err,
+		Note:     note,
+	}
+
+	return parsetypes.Diagnostics{diag}
+}
+
+func parameterRequiredDiagnostic(name string, argsLocation *ReferenceLocation) *parsetypes.Diagnostic {
+	return &parsetypes.Diagnostic{
+		FileName: argsLocation.FileName,
+		Severity: parsetypes.DiagnosticSeverityError,
+		Range:    argsLocation.Range,
+		Offset:   argsLocation.Offset,
+		Err:      fmt.Errorf("input parameter %q is required", name),
+	}
+}

--- a/internal/v2/manifest/binder.go
+++ b/internal/v2/manifest/binder.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
+	"time"
 
 	"github.com/go-gilbert/gilbert/pkg/expr"
 	"github.com/go-gilbert/gilbert/pkg/parsetypes"
@@ -202,29 +204,153 @@ func mapLazyValue(ctx context.Context, val *LazyValue, opts valueMapOpts) (any, 
 		return nil, newDiagnostic(val.Location, err, opts.note)
 	}
 
+	return mapRawValue(raw, val.Location, opts)
+}
+
+func mapRawValue(raw any, loc *ReferenceLocation, opts valueMapOpts) (any, parsetypes.Diagnostics) {
 	if t, ok := raw.(string); ok {
 		out, err := opts.spec.ParseValue(t)
 		if err != nil {
-			return nil, newDiagnostic(val.Location, err, opts.note)
+			return nil, newDiagnostic(loc, err, opts.note)
 		}
 
 		return out, nil
 	}
 
-	if !opts.allowNil {
-		if raw == nil {
-			return nil, newDiagnostic(val.Location, errors.New("value cannot be nil"), opts.note)
+	if isNilValue(raw) {
+		if !opts.allowNil {
+			return nil, newDiagnostic(loc, errors.New("value cannot be nil"), opts.note)
 		}
 
-		// TODO: handle iface with nil value
+		if !opts.spec.Type.IsComplex() {
+			return NewZeroValue(opts.spec.Type), nil
+		}
+
+		return nil, nil
 	}
+
+	var (
+		out any
+		err error
+	)
 
 	switch opts.spec.Type {
-	// TODO: typecheck.
-	// NOTE: some scalar values can be casted between.
+	case ValueTypeString:
+		out, err = parsetypes.AnyToString(raw)
+	case ValueTypeBool:
+		out, err = parsetypes.AnyToBool(raw)
+	case ValueTypeInt:
+		out, err = parsetypes.AnyToInt(raw)
+	case ValueTypeFloat:
+		out, err = parsetypes.AnyToFloat(raw)
+	case ValueTypeDate:
+		out, err = anyToDate(raw, opts.spec.DateFormatOrDefault())
+	case ValueTypeDuration:
+		out, err = parsetypes.AnyToDuration(raw)
+	case ValueTypeList:
+		out, err = anyToTypedList(raw, loc, opts)
+	case ValueTypeDict:
+		out, err = anyToTypedDict(raw, loc, opts)
+	default:
+		err = fmt.Errorf("unsupported value type: %s", opts.spec.Type)
 	}
 
-	return nil, nil
+	if err != nil {
+		return nil, newDiagnostic(loc, err, opts.note)
+	}
+
+	return out, nil
+}
+
+func isNilValue(v any) bool {
+	if v == nil {
+		return true
+	}
+
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return rv.IsNil()
+	default:
+		return false
+	}
+}
+
+func anyToDate(v any, dateFormat string) (time.Time, error) {
+	switch t := v.(type) {
+	case time.Time:
+		return t, nil
+	case []byte:
+		return time.Parse(dateFormat, string(t))
+	default:
+		return time.Time{}, fmt.Errorf("value of type %T cannot be converted to date", v)
+	}
+}
+
+func anyToTypedList(v any, loc *ReferenceLocation, opts valueMapOpts) ([]any, error) {
+	list, err := parsetypes.AnyToList(v)
+	if err != nil || opts.spec.Items == nil {
+		return list, err
+	}
+
+	out := make([]any, len(list))
+	itemOpts := valueMapOpts{
+		ep:       opts.ep,
+		spec:     *opts.spec.Items,
+		note:     opts.note,
+		allowNil: true,
+	}
+
+	for i, item := range list {
+		val, diags := mapRawValue(item, loc, itemOpts)
+		if diags.HasError() {
+			return nil, fmt.Errorf("invalid value at index %d: %w", i, diags[0].Err)
+		}
+
+		out[i] = val
+	}
+
+	return out, nil
+}
+
+func anyToTypedDict(v any, loc *ReferenceLocation, opts valueMapOpts) (map[string]any, error) {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Map {
+		return nil, fmt.Errorf("expected a dict, but got %s %#v", rv.Kind(), v)
+	}
+
+	out := make(map[string]any, rv.Len())
+	iter := rv.MapRange()
+	for iter.Next() {
+		key := iter.Key()
+		if key.Kind() != reflect.String {
+			return nil, fmt.Errorf("dict key type should be string, got %s", key.Kind())
+		}
+
+		out[key.String()] = iter.Value().Interface()
+	}
+
+	if opts.spec.Items == nil {
+		return out, nil
+	}
+
+	itemOpts := valueMapOpts{
+		ep:       opts.ep,
+		spec:     *opts.spec.Items,
+		note:     opts.note,
+		allowNil: true,
+	}
+
+	for key, item := range out {
+		val, diags := mapRawValue(item, loc, itemOpts)
+		if diags.HasError() {
+			return nil, fmt.Errorf("invalid value for key %q: %w", key, diags[0].Err)
+		}
+
+		out[key] = val
+	}
+
+	return out, nil
 }
 
 func newDiagnostic(loc *ReferenceLocation, err error, note string) parsetypes.Diagnostics {

--- a/internal/v2/manifest/binder_test.go
+++ b/internal/v2/manifest/binder_test.go
@@ -1,0 +1,113 @@
+package manifest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapLazyValueCastsScalars(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  any
+		spec TypeSchema
+		want any
+	}{
+		{
+			name: "string parses through schema",
+			raw:  "42",
+			spec: TypeSchema{Type: ValueTypeInt},
+			want: int64(42),
+		},
+		{
+			name: "non-string becomes string",
+			raw:  42,
+			spec: TypeSchema{Type: ValueTypeString},
+			want: "42",
+		},
+		{
+			name: "bool casts",
+			raw:  1,
+			spec: TypeSchema{Type: ValueTypeBool},
+			want: true,
+		},
+		{
+			name: "duration casts",
+			raw:  1500,
+			spec: TypeSchema{Type: ValueTypeDuration},
+			want: 1500 * time.Millisecond,
+		},
+		{
+			name: "nil scalar becomes zero value",
+			raw:  nil,
+			spec: TypeSchema{Type: ValueTypeString},
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, diags := mapLazyValue(context.Background(), literalLazyValue(tc.raw), valueMapOpts{
+				spec:     tc.spec,
+				allowNil: true,
+			})
+			require.False(t, diags.HasError(), "unexpected diagnostics: %v", diags)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestMapLazyValueCastsListItems(t *testing.T) {
+	got, diags := mapLazyValue(context.Background(), literalLazyValue([]int{1, 2, 3}), valueMapOpts{
+		spec: TypeSchema{
+			Type:  ValueTypeList,
+			Items: &TypeSchema{Type: ValueTypeFloat},
+		},
+		allowNil: true,
+	})
+	require.False(t, diags.HasError(), "unexpected diagnostics: %v", diags)
+	require.Equal(t, []any{float64(1), float64(2), float64(3)}, got)
+}
+
+func TestMapLazyValueCastsDictItems(t *testing.T) {
+	got, diags := mapLazyValue(context.Background(), literalLazyValue(map[string]any{
+		"enabled": 1,
+		"empty":   nil,
+	}), valueMapOpts{
+		spec: TypeSchema{
+			Type:  ValueTypeDict,
+			Items: &TypeSchema{Type: ValueTypeBool},
+		},
+		allowNil: true,
+	})
+	require.False(t, diags.HasError(), "unexpected diagnostics: %v", diags)
+	require.Equal(t, map[string]any{
+		"enabled": true,
+		"empty":   false,
+	}, got)
+}
+
+func TestMapLazyValueReportsNestedTypeErrors(t *testing.T) {
+	_, diags := mapLazyValue(context.Background(), literalLazyValue([]any{"nope"}), valueMapOpts{
+		spec: TypeSchema{
+			Type:  ValueTypeList,
+			Items: &TypeSchema{Type: ValueTypeInt},
+		},
+		allowNil: true,
+	})
+	require.True(t, diags.HasError())
+	require.Contains(t, diags[0].Err.Error(), "invalid value at index 0")
+}
+
+func literalLazyValue(v any) *LazyValue {
+	return &LazyValue{
+		Location: &ReferenceLocation{},
+		Value: AnySpec{
+			LiteralSpec: &LiteralSpec{
+				Value: v,
+			},
+		},
+	}
+}

--- a/internal/v2/manifest/jobfile.go
+++ b/internal/v2/manifest/jobfile.go
@@ -2,6 +2,7 @@ package manifest
 
 import (
 	"context"
+	"fmt"
 	"time"
 )
 
@@ -22,8 +23,10 @@ func (k JobKind) String() string {
 		return "mixin"
 	case JobKindTask:
 		return "task"
-	default:
+	case JobKindUnknown:
 		return "<unknown>"
+	default:
+		return fmt.Sprintf("<unknown>(%d)", k)
 	}
 }
 

--- a/internal/v2/manifest/jobfile.go
+++ b/internal/v2/manifest/jobfile.go
@@ -14,6 +14,19 @@ const (
 	JobKindTask
 )
 
+func (k JobKind) String() string {
+	switch k {
+	case JobKindAction:
+		return "action"
+	case JobKindMixin:
+		return "mixin"
+	case JobKindTask:
+		return "task"
+	default:
+		return "<unknown>"
+	}
+}
+
 type JobGroupType uint8
 
 const (

--- a/internal/v2/manifest/loader/yamlloader/task.go
+++ b/internal/v2/manifest/loader/yamlloader/task.go
@@ -70,6 +70,12 @@ var jobSchema = Struct(
 		},
 	).CheckNode(setJobTargetValueLoc),
 	Field(
+		"task", String(),
+		func(ctx context.Context, dst *manifest.Job, val string) error {
+			return setJobTarget(ctx, dst, manifest.JobKindTask, val)
+		},
+	).CheckNode(setJobTargetValueLoc),
+	Field(
 		"async", Bool(),
 		func(_ context.Context, dst *manifest.Job, v bool) error {
 			dst.Async = v

--- a/internal/v2/manifest/type.go
+++ b/internal/v2/manifest/type.go
@@ -172,7 +172,7 @@ func (s TypeSchema) ParseValue(val string) (any, error) {
 func (s TypeSchema) String() string {
 	switch s.Type {
 	case ValueTypeBool:
-		return "boolean"
+		return "bool"
 	case ValueTypeInt:
 		return "int"
 	case ValueTypeFloat:

--- a/internal/v2/scope/scope.go
+++ b/internal/v2/scope/scope.go
@@ -1,5 +1,7 @@
 package scope
 
+import "path/filepath"
+
 const (
 	projectFieldsCount = 2
 	scopeFieldsCount   = 2
@@ -87,6 +89,21 @@ func (s *Scope) WithMatrixValues(labels []string, values []any) *Scope {
 	}
 
 	s.MatrixValues = m
+	return s
+}
+
+// WithWorkDir updates working directory of current scope.
+func (s *Scope) WithWorkDir(wd string) *Scope {
+	if wd == "" {
+		return s
+	}
+
+	newWd := wd
+	if !filepath.IsAbs(newWd) {
+		newWd = filepath.Join(s.Globals.Project.WorkDir, newWd)
+	}
+
+	s.Globals.Project.WorkDir = filepath.Clean(newWd)
 	return s
 }
 

--- a/internal/v2/ui/headless.go
+++ b/internal/v2/ui/headless.go
@@ -46,8 +46,12 @@ func (l *LogReporter) OnJobStart(e engine.JobStartEvent) {
 	l.log.Infow("starting job", fields...)
 }
 
-func (l *LogReporter) OnTaskStart(taskName string) {
-	l.log.Infof("starting task %q", taskName)
+func (l *LogReporter) OnTaskStart(event engine.TaskStartEvent) {
+	l.log.Infow(
+		"starting task",
+		log.NewField("name", event.TaskName),
+		log.NewField("isSubTask", event.IsSubTask),
+	)
 }
 
 func (l *LogReporter) OnSignal(event engine.SignalEvent) {

--- a/internal/v2/ui/terminal.go
+++ b/internal/v2/ui/terminal.go
@@ -47,8 +47,13 @@ func NewTerminalReporter(stdio log.IOStreams, palette theme.Palette) *TerminalRe
 	}
 }
 
-func (r *TerminalReporter) OnTaskStart(taskName string) {
-	r.Printf(r.palette.TextHeading, ":: Running task %q\n", taskName)
+func (r *TerminalReporter) OnTaskStart(event engine.TaskStartEvent) {
+	if event.IsSubTask {
+		r.Printf(r.palette.NoteMarker, ":: Running sub-task %q\n", event.TaskName)
+		return
+	}
+
+	r.Printf(r.palette.TextHeading, ":: Running task %q\n", event.TaskName)
 }
 
 func (r *TerminalReporter) OnJobStart(e engine.JobStartEvent) {

--- a/pkg/parsetypes/cast.go
+++ b/pkg/parsetypes/cast.go
@@ -242,6 +242,10 @@ func AnyToDuration(v any) (time.Duration, error) {
 }
 
 func AnyToList(v any) ([]any, error) {
+	if v == nil {
+		return nil, nil
+	}
+
 	if l, ok := v.([]any); ok {
 		return l, nil
 	}

--- a/pkg/parsetypes/cast.go
+++ b/pkg/parsetypes/cast.go
@@ -167,6 +167,8 @@ func AnyToInt(v any) (int64, error) {
 
 func AnyToFloat(v any) (float64, error) {
 	switch t := v.(type) {
+	case int:
+		return float64(t), nil
 	case int8:
 		return float64(t), nil
 	case int16:
@@ -174,6 +176,8 @@ func AnyToFloat(v any) (float64, error) {
 	case int32:
 		return float64(t), nil
 	case int64:
+		return float64(t), nil
+	case uint:
 		return float64(t), nil
 	case uint8:
 		return float64(t), nil


### PR DESCRIPTION
This PR adds support of calling sub-tasks and mixins, which are reusable pieces of pipeline.

### Examples

#### Mixins

Mixins allow decoupling repeated pieces of pipeline into separate blocks.


Mixins, like tasks, support accepting inputs.

```yaml
mixins:
  hello:
    inputs:
      name:
        type: string
      greeting:
        type: string
        default: Hello
    steps:
      - action: debug/echo
        with:
          message: "${{inputs.greeting}}, ${{inputs.name}}!"
      - action: debug/echo
        delay: 300ms
        with:
          message: "Goodbye, ${{inputs.name}}"

tasks:
  test:
    steps:
      - mixin: hello
        with:
          name: Alice 
```

#### Subtasks

Tasks can be called inside another tasks, similar to mixins:

```yaml
tasks:
  foo:
    steps:
      ...
  bar:
    steps:
      - task: foo # foo calls bar
```